### PR TITLE
add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,10 @@ jobs:
       with:
         distribution: "corretto"
         java-version: ${{ matrix.java }}
+    - name: "Setup gradle"
+      uses: "gradle/actions/setup-gradle@v5"
+      with:
+        add-job-summary: "on-failure"
     - name: "Check Java version"
       run: |
         java -version


### PR DESCRIPTION
This PR adds GitHub Actions configuration to build `openssl` from `openssl-3.6` branch and build `jostle` jar for Linux `x86_64` and Linux `aarch64` platforms. The workflow run you can find [here](https://github.com/quarckster/openssl-jostle/actions/runs/19036062124). I couldn't build the jar for Java 8 and 17.