### PR TITLE
Remove unused POSIX header from Windows native build path

### DIFF
--- a/interface/util/ops.c
+++ b/interface/util/ops.c
@@ -13,7 +13,6 @@
 
 #include "jo_assert.h"
 #include "rand/jostle_lib_ctx.h"
-#include <unistd.h>
 
 #ifdef JOSTLE_OPS
 


### PR DESCRIPTION
Remove an unused `unistd.h` include from here:
https://github.com/openssl-projects/openssl-jostle/blob/main/interface/util/ops.c#L16

The header is available on Linux and macOS, so the issue did not appear there, but it is not provided by the Windows clang-cl/MSVC toolchain, which caused the native Windows build to fail. The include was not needed by this file, so removing it fixes the portability issue without changing behavior.