### PR TITLE
Exclude native library binaries from NoHttp scanning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ subprojects {
         source.exclude '**/*.class'
         source.exclude '**/*.crt'
         source.exclude '**/*.crl'
+        source.exclude '**/*.dll'
+        source.exclude '**/*.dylib'
         source.exclude '**/*.eml'
         source.exclude '**/*.gpg'
         source.exclude '**/*.jar'
@@ -59,6 +61,7 @@ subprojects {
         source.exclude '**/*.pem'
         source.exclude '**/*.*pub'
         source.exclude '**/*.rsp'
+        source.exclude '**/*.so'
         source.exclude 'out/*'
     }
 


### PR DESCRIPTION
This change updates the shared NoHttp configuration to exclude native library artifacts (*.dll, *.so, *.dylib).

Without this, :jostle:checkstyleNohttp can fail when packaged native binaries under contain embedded http:// strings from upstream signing/certificate metadata, such as the Windows libcrypto-3-x64.dll. These are binary resources, not source files, so I believe they should not be checked by the NoHttp rule.