### PR TITLE
Fixed AES fixed-size key generator NPE

### DIFF
--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/AESKeyGenerator.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/AESKeyGenerator.java
@@ -12,6 +12,7 @@
 package org.openssl.jostle.jcajce.provider.blockcipher;
 
 
+import org.openssl.jostle.CryptoServicesRegistrar;
 import org.openssl.jostle.jcajce.provider.ProvSecretKeySpec;
 
 import javax.crypto.KeyGeneratorSpi;
@@ -32,12 +33,13 @@ public class AESKeyGenerator extends KeyGeneratorSpi
 
     public AESKeyGenerator()
     {
-        random = new SecureRandom();
+        random = CryptoServicesRegistrar.getSecureRandom();
         keySize = 256;
     }
 
     public AESKeyGenerator(int fixedSize)
     {
+        random = CryptoServicesRegistrar.getSecureRandom();
         this.fixedKeySize = fixedSize;
         this.keySize = fixedSize;
     }

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESKeyGeneratorTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESKeyGeneratorTest.java
@@ -117,6 +117,20 @@ public class AESKeyGeneratorTest
         Assertions.assertFalse(Arrays.areAllZeroes(keyBytes, 0, keyBytes.length));
     }
 
+    @Test
+    public void testGen_fixedSizesWithoutInit() throws Exception
+    {
+        for (String algorithm : new String[]{"AES128", "AES192", "AES256"})
+        {
+            KeyGenerator keyGen = KeyGenerator.getInstance(algorithm, JostleProvider.PROVIDER_NAME);
+            byte[] keyBytes = keyGen.generateKey().getEncoded();
+            int expectedSize = Integer.parseInt(algorithm.substring("AES".length()));
+
+            Assertions.assertEquals(expectedSize, keyBytes.length << 3);
+            Assertions.assertFalse(Arrays.areAllZeroes(keyBytes, 0, keyBytes.length));
+        }
+    }
+
 
     @Test
     public void testGen_validKeySizes() throws Exception


### PR DESCRIPTION
The AES key generator constructor that takes a fixed size as a parameter did not initialize the default SecureRandom, so generateKey() without an explicit init() could fail with a NullPointerException. I initialized the fixed-size constructor with the provider default random source and added a regression test.