### PR TITLE
Cache fixed crypto output lengths with native fallback

### DIFF
--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherLengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherLengths.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.blockcipher;
+
+final class BlockCipherLengths
+{
+    static final int UNKNOWN_BLOCK_SIZE = -1;
+
+    private BlockCipherLengths()
+    {
+    }
+
+    static int getBlockSize(OSSLCipher cipher)
+    {
+        if (cipher == null)
+        {
+            return UNKNOWN_BLOCK_SIZE;
+        }
+
+        switch (cipher)
+        {
+            case AES128:
+            case AES192:
+            case AES256:
+            case ARIA128:
+            case ARIA192:
+            case ARIA256:
+            case CAMELLIA128:
+            case CAMELLIA192:
+            case CAMELLIA256:
+            case SM4:
+                return 16;
+            case DES_EDE3:
+                return 8;
+            default:
+                return UNKNOWN_BLOCK_SIZE;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -136,7 +136,11 @@ class BlockCipherSpi extends CipherSpi
 
             if (blockSize == 0)
             {
-                blockSize = blockCipherNi.getBlockSize(refWrapper.getReference());
+                blockSize = BlockCipherLengths.getBlockSize(osslCipher);
+                if (blockSize == BlockCipherLengths.UNKNOWN_BLOCK_SIZE)
+                {
+                    blockSize = blockCipherNi.getBlockSize(refWrapper.getReference());
+                }
             }
 
             return blockSize;

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdDSALengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdDSALengths.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.ed;
+
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+final class EdDSALengths
+{
+    static final int UNKNOWN_SIGNATURE_LENGTH = -1;
+
+    private EdDSALengths()
+    {
+    }
+
+    static int getSignatureLength(OSSLKeyType type)
+    {
+        if (type == null)
+        {
+            return UNKNOWN_SIGNATURE_LENGTH;
+        }
+
+        switch (type)
+        {
+            case ED25519:
+            case Ed25519ctx:
+            case Ed25519ph:
+                return 64;
+            case ED448:
+            case ED448ph:
+                return 114;
+            default:
+                return UNKNOWN_SIGNATURE_LENGTH;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
@@ -203,9 +203,21 @@ public class EdSignatureSpi extends SignatureSpi
             byte[] sig = null;
             try
             {
-                long len = edServiceNI.sign(ref.getReference(), null, 0, randSource);
-                sig = new byte[(int) len];
-                edServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                int len = EdDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+                if (lastKey instanceof JOEdPrivateKey)
+                {
+                    len = EdDSALengths.getSignatureLength(((JOEdPrivateKey) lastKey).getType());
+                }
+                if (len == EdDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+                {
+                    len = edServiceNI.sign(ref.getReference(), null, 0, randSource);
+                }
+                sig = new byte[len];
+                int written = edServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                if (written != sig.length)
+                {
+                    throw new SignatureException("signature length mismatch");
+                }
                 return sig;
             }
             finally

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mac/MacLengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mac/MacLengths.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mac;
+
+final class MacLengths
+{
+    static final int UNKNOWN_MAC_LENGTH = -1;
+
+    private MacLengths()
+    {
+    }
+
+    static int getMacLength(String macName, String function)
+    {
+        if ("CMAC".equals(macName))
+        {
+            if ("aes-cbc".equals(function))
+            {
+                return 16;
+            }
+            return UNKNOWN_MAC_LENGTH;
+        }
+
+        if (!"HMAC".equals(macName) || function == null)
+        {
+            return UNKNOWN_MAC_LENGTH;
+        }
+
+        switch (function)
+        {
+            case "SHA-1":
+            case "SHA1":
+                return 20;
+            case "SHA2-224":
+                return 28;
+            case "SHA2-256":
+                return 32;
+            case "SHA2-384":
+                return 48;
+            case "SHA2-512":
+                return 64;
+            case "SHA2-512/224":
+                return 28;
+            case "SHA2-512/256":
+                return 32;
+            case "SHA3-224":
+                return 28;
+            case "SHA3-256":
+                return 32;
+            case "SHA3-384":
+                return 48;
+            case "SHA3-512":
+                return 64;
+            case "MD5":
+                return 16;
+            case "MD5-SHA1":
+                return 36;
+            case "SM3":
+                return 32;
+            case "RIPEMD-160":
+                return 20;
+            default:
+                return UNKNOWN_MAC_LENGTH;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mac/MacServiceSPI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mac/MacServiceSPI.java
@@ -19,6 +19,7 @@ import javax.crypto.SecretKey;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.ProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 
 public class MacServiceSPI extends MacSpi
@@ -26,18 +27,27 @@ public class MacServiceSPI extends MacSpi
     private static final MacServiceNI macServiceNI = NISelector.MacServiceNI;
 
     private final MacReference ref;
+    private final int fixedMacLength;
+    private volatile int initializedMacLength = MacLengths.UNKNOWN_MAC_LENGTH;
 
     public MacServiceSPI(String macName, String function)
     {
         this.ref = new MacReference(macServiceNI.allocateMac(macName, function), function);
+
+        this.fixedMacLength = MacLengths.getMacLength(macName, function);
     }
 
     @Override
     protected int engineGetMacLength()
     {
+        if (fixedMacLength != MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            return fixedMacLength;
+        }
+
         synchronized (this)
         {
-            return macServiceNI.getMacLength(ref.getReference());
+            return getInitializedMacLength();
         }
     }
 
@@ -67,7 +77,15 @@ public class MacServiceSPI extends MacSpi
 
         synchronized (this)
         {
+            if (fixedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+            {
+                initializedMacLength = MacLengths.UNKNOWN_MAC_LENGTH;
+            }
             macServiceNI.engineInit(ref.getReference(), keyBytes);
+            if (fixedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+            {
+                initializedMacLength = macServiceNI.getMacLength(ref.getReference());
+            }
         }
     }
 
@@ -94,7 +112,7 @@ public class MacServiceSPI extends MacSpi
     {
         synchronized (this)
         {
-            byte[] out = new byte[engineGetMacLength()];
+            byte[] out = new byte[getInitializedMacLength()];
             int written = macServiceNI.doFinal(ref.getReference(), out, 0);
             macServiceNI.reset(ref.getReference());
             if (written == out.length)
@@ -102,9 +120,7 @@ public class MacServiceSPI extends MacSpi
                 return out;
             }
 
-            byte[] exact = new byte[written];
-            System.arraycopy(out, 0, exact, 0, written);
-            return exact;
+            throw new ProviderException("MAC length mismatch");
         }
     }
 
@@ -115,6 +131,19 @@ public class MacServiceSPI extends MacSpi
         {
             macServiceNI.reset(ref.getReference());
         }
+    }
+
+    private int getInitializedMacLength()
+    {
+        if (fixedMacLength != MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            return fixedMacLength;
+        }
+        if (initializedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            initializedMacLength = macServiceNI.getMacLength(ref.getReference());
+        }
+        return initializedMacLength;
     }
 
     private static class Disposer extends NativeDisposer

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSALengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSALengths.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mldsa;
+
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+final class MLDSALengths
+{
+    static final int UNKNOWN_SIGNATURE_LENGTH = -1;
+
+    private MLDSALengths()
+    {
+    }
+
+    static int getSignatureLength(OSSLKeyType type, boolean calculateMu)
+    {
+        if (calculateMu)
+        {
+            return UNKNOWN_SIGNATURE_LENGTH;
+        }
+
+        if (type == null)
+        {
+            return UNKNOWN_SIGNATURE_LENGTH;
+        }
+
+        switch (type)
+        {
+            case ML_DSA_44:
+                return 2420;
+            case ML_DSA_65:
+                return 3309;
+            case ML_DSA_87:
+                return 4627;
+            default:
+                return UNKNOWN_SIGNATURE_LENGTH;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSASignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSASignatureSpi.java
@@ -159,9 +159,23 @@ public class MLDSASignatureSpi extends SignatureSpi
         byte[] sig = null;
         try
         {
-            long len = NISelector.MLDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
-            sig = new byte[(int) len];
-            NISelector.MLDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            int len = MLDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+            if (lastKey != null)
+            {
+                len = MLDSALengths.getSignatureLength(
+                        lastKey.getSpec().getType(),
+                        muHandling == MuHandling.CALCULATE_MU);
+            }
+            if (len == MLDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+            {
+                len = NISelector.MLDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
+            }
+            sig = new byte[len];
+            int written = NISelector.MLDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            if (written != sig.length)
+            {
+                throw new SignatureException("signature length mismatch");
+            }
             return sig;
         }
         finally

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyGenerator.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyGenerator.java
@@ -171,9 +171,13 @@ public class MLKEMKeyGenerator extends KeyGeneratorSpi
             // engineInit resolved randSource for the peer key's
             // strength category — use it directly.
             byte[] secret = new byte[generateSpec.getKeySizeInBits() / 8];
-            long len = NISelector.SpecNI.encap(spec.getReference(), null, secret, 0, secret.length, null, 0, 0, randSource);
-            byte[] wrappedKey = new byte[(int) len];
-            len = NISelector.SpecNI.encap(spec.getReference(), null, secret, 0, secret.length, wrappedKey, 0, wrappedKey.length, randSource);
+            int encapsulationLen = MLKEMLengths.getEncapsulationLength(spec.getType());
+            if (encapsulationLen == MLKEMLengths.UNKNOWN_ENCAPSULATION_LENGTH)
+            {
+                encapsulationLen = NISelector.SpecNI.encap(spec.getReference(), null, secret, 0, secret.length, null, 0, 0, randSource);
+            }
+            byte[] wrappedKey = new byte[encapsulationLen];
+            int len = NISelector.SpecNI.encap(spec.getReference(), null, secret, 0, secret.length, wrappedKey, 0, wrappedKey.length, randSource);
 
             if (len != wrappedKey.length)
             {

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMLengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMLengths.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mlkem;
+
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+final class MLKEMLengths
+{
+    static final int UNKNOWN_ENCAPSULATION_LENGTH = -1;
+
+    private MLKEMLengths()
+    {
+    }
+
+    static int getEncapsulationLength(OSSLKeyType type)
+    {
+        if (type == null)
+        {
+            return UNKNOWN_ENCAPSULATION_LENGTH;
+        }
+
+        switch (type)
+        {
+            case ML_KEM_512:
+                return 768;
+            case ML_KEM_768:
+                return 1088;
+            case ML_KEM_1024:
+                return 1568;
+            default:
+                return UNKNOWN_ENCAPSULATION_LENGTH;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSALengths.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSALengths.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.slhdsa;
+
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+final class SLHDSALengths
+{
+    static final int UNKNOWN_SIGNATURE_LENGTH = -1;
+
+    private SLHDSALengths()
+    {
+    }
+
+    static int getSignatureLength(OSSLKeyType type)
+    {
+        if (type == null)
+        {
+            return UNKNOWN_SIGNATURE_LENGTH;
+        }
+
+        switch (type)
+        {
+            case SLH_DSA_SHA2_128s:
+            case SLH_DSA_SHAKE_128s:
+                return 7856;
+            case SLH_DSA_SHA2_128f:
+            case SLH_DSA_SHAKE_128f:
+                return 17088;
+            case SLH_DSA_SHA2_192s:
+            case SLH_DSA_SHAKE_192s:
+                return 16224;
+            case SLH_DSA_SHA2_192f:
+            case SLH_DSA_SHAKE_192f:
+                return 35664;
+            case SLH_DSA_SHA2_256s:
+            case SLH_DSA_SHAKE_256s:
+                return 29792;
+            case SLH_DSA_SHA2_256f:
+            case SLH_DSA_SHAKE_256f:
+                return 49856;
+            default:
+                return UNKNOWN_SIGNATURE_LENGTH;
+        }
+    }
+
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSASignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSASignatureSpi.java
@@ -187,9 +187,21 @@ public class SLHDSASignatureSpi extends SignatureSpi
             byte[] sig = null;
             try
             {
-                long len = NISelector.SLHDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
-                sig = new byte[(int) len];
-                NISelector.SLHDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                int len = SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+                if (lastKey != null)
+                {
+                    len = SLHDSALengths.getSignatureLength(lastKey.getType());
+                }
+                if (len == SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+                {
+                    len = (int) NISelector.SLHDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
+                }
+                sig = new byte[len];
+                long written = NISelector.SLHDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                if (written != sig.length)
+                {
+                    throw new SignatureException("signature length mismatch");
+                }
                 return sig;
             }
             finally

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -137,7 +137,11 @@ class BlockCipherSpi extends CipherSpi
 
             if (blockSize == 0)
             {
-                blockSize = blockCipherNi.getBlockSize(refWrapper.getReference());
+                blockSize = BlockCipherLengths.getBlockSize(osslCipher);
+                if (blockSize == BlockCipherLengths.UNKNOWN_BLOCK_SIZE)
+                {
+                    blockSize = blockCipherNi.getBlockSize(refWrapper.getReference());
+                }
             }
 
             return blockSize;

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
@@ -214,9 +214,21 @@ public class EdSignatureSpi extends SignatureSpi
         byte[] sig = null;
         try
         {
-            long len = edServiceNI.sign(ref.getReference(), null, 0, randSource);
-            sig = new byte[(int) len];
-            edServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            int len = EdDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+            if (lastKey instanceof JOEdPrivateKey)
+            {
+                len = EdDSALengths.getSignatureLength(((JOEdPrivateKey) lastKey).getType());
+            }
+            if (len == EdDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+            {
+                len = edServiceNI.sign(ref.getReference(), null, 0, randSource);
+            }
+            sig = new byte[len];
+            int written = edServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            if (written != sig.length)
+            {
+                throw new SignatureException("signature length mismatch");
+            }
             return sig;
         }
         finally

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/mac/MacServiceSPI.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/mac/MacServiceSPI.java
@@ -20,6 +20,7 @@ import java.lang.ref.Reference;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.ProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 
 public class MacServiceSPI extends MacSpi
@@ -27,18 +28,27 @@ public class MacServiceSPI extends MacSpi
     private static final MacServiceNI macServiceNI = NISelector.MacServiceNI;
 
     private final MacReference ref;
+    private final int fixedMacLength;
+    private volatile int initializedMacLength = MacLengths.UNKNOWN_MAC_LENGTH;
 
     public MacServiceSPI(String macName, String function)
     {
         this.ref = new MacReference(macServiceNI.allocateMac(macName, function), function);
+
+        this.fixedMacLength = MacLengths.getMacLength(macName, function);
     }
 
     @Override
     protected int engineGetMacLength()
     {
+        if (fixedMacLength != MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            return fixedMacLength;
+        }
+
         try
         {
-            return macServiceNI.getMacLength(ref.getReference());
+            return getInitializedMacLength();
         }
         finally
         {
@@ -72,7 +82,15 @@ public class MacServiceSPI extends MacSpi
 
         try
         {
+            if (fixedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+            {
+                initializedMacLength = MacLengths.UNKNOWN_MAC_LENGTH;
+            }
             macServiceNI.engineInit(ref.getReference(), keyBytes);
+            if (fixedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+            {
+                initializedMacLength = macServiceNI.getMacLength(ref.getReference());
+            }
         }
         finally
         {
@@ -111,7 +129,7 @@ public class MacServiceSPI extends MacSpi
     {
         try
         {
-            byte[] out = new byte[engineGetMacLength()];
+            byte[] out = new byte[getInitializedMacLength()];
             int written = macServiceNI.doFinal(ref.getReference(), out, 0);
             macServiceNI.reset(ref.getReference());
             if (written == out.length)
@@ -119,9 +137,7 @@ public class MacServiceSPI extends MacSpi
                 return out;
             }
 
-            byte[] exact = new byte[written];
-            System.arraycopy(out, 0, exact, 0, written);
-            return exact;
+            throw new ProviderException("MAC length mismatch");
         }
         finally
         {
@@ -142,6 +158,18 @@ public class MacServiceSPI extends MacSpi
         }
     }
 
+    private int getInitializedMacLength()
+    {
+        if (fixedMacLength != MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            return fixedMacLength;
+        }
+        if (initializedMacLength == MacLengths.UNKNOWN_MAC_LENGTH)
+        {
+            initializedMacLength = macServiceNI.getMacLength(ref.getReference());
+        }
+        return initializedMacLength;
+    }
 
     private static class Disposer extends NativeDisposer
     {

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/mldsa/MLDSASignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/mldsa/MLDSASignatureSpi.java
@@ -168,9 +168,23 @@ public class MLDSASignatureSpi extends SignatureSpi
         byte[] sig = null;
         try
         {
-            long len = NISelector.MLDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
-            sig = new byte[(int) len];
-            NISelector.MLDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            int len = MLDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+            if (lastKey != null)
+            {
+                len = MLDSALengths.getSignatureLength(
+                        lastKey.getSpec().getType(),
+                        muHandling == MuHandling.CALCULATE_MU);
+            }
+            if (len == MLDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+            {
+                len = NISelector.MLDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
+            }
+            sig = new byte[len];
+            int written = NISelector.MLDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+            if (written != sig.length)
+            {
+                throw new SignatureException("signature length mismatch");
+            }
             return sig;
         }
         finally

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSASignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSASignatureSpi.java
@@ -200,9 +200,21 @@ public class SLHDSASignatureSpi extends SignatureSpi
             byte[] sig = null;
             try
             {
-                long len = NISelector.SLHDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
-                sig = new byte[(int) len];
-                NISelector.SLHDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                int len = SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH;
+                if (lastKey != null)
+                {
+                    len = SLHDSALengths.getSignatureLength(lastKey.getType());
+                }
+                if (len == SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH)
+                {
+                    len = (int) NISelector.SLHDSAServiceNI.sign(ref.getReference(), null, 0, randSource);
+                }
+                sig = new byte[len];
+                long written = NISelector.SLHDSAServiceNI.sign(ref.getReference(), sig, 0, randSource);
+                if (written != sig.length)
+                {
+                    throw new SignatureException("signature length mismatch");
+                }
                 return sig;
             }
             finally

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherLengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherLengthsTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.blockcipher;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BlockCipherLengthsTest
+{
+    @Test
+    public void testKnownBlockSizes()
+    {
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.AES128));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.AES192));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.AES256));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.ARIA128));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.ARIA192));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.ARIA256));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.CAMELLIA128));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.CAMELLIA192));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.CAMELLIA256));
+        Assertions.assertEquals(16, BlockCipherLengths.getBlockSize(OSSLCipher.SM4));
+        Assertions.assertEquals(8, BlockCipherLengths.getBlockSize(OSSLCipher.DES_EDE3));
+    }
+
+    @Test
+    public void testUnknownBlockSizesUseNativeFallback()
+    {
+        Assertions.assertEquals(BlockCipherLengths.UNKNOWN_BLOCK_SIZE, BlockCipherLengths.getBlockSize(null));
+        Assertions.assertEquals(BlockCipherLengths.UNKNOWN_BLOCK_SIZE, BlockCipherLengths.getBlockSize(OSSLCipher.RC4));
+        Assertions.assertEquals(BlockCipherLengths.UNKNOWN_BLOCK_SIZE,
+                BlockCipherLengths.getBlockSize(OSSLCipher.CHACHA20_POLY1305));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/ed/EdDSALengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/ed/EdDSALengthsTest.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.ed;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+public class EdDSALengthsTest
+{
+    @Test
+    public void testKnownSignatureLengths()
+    {
+        Assertions.assertEquals(64, EdDSALengths.getSignatureLength(OSSLKeyType.ED25519));
+        Assertions.assertEquals(64, EdDSALengths.getSignatureLength(OSSLKeyType.Ed25519ctx));
+        Assertions.assertEquals(64, EdDSALengths.getSignatureLength(OSSLKeyType.Ed25519ph));
+        Assertions.assertEquals(114, EdDSALengths.getSignatureLength(OSSLKeyType.ED448));
+        Assertions.assertEquals(114, EdDSALengths.getSignatureLength(OSSLKeyType.ED448ph));
+    }
+
+    @Test
+    public void testUnknownSignatureLengthsUseNativeFallback()
+    {
+        Assertions.assertEquals(EdDSALengths.UNKNOWN_SIGNATURE_LENGTH, EdDSALengths.getSignatureLength(null));
+        Assertions.assertEquals(EdDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                EdDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_44));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mac/MacLengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mac/MacLengthsTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mac;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MacLengthsTest
+{
+    @Test
+    public void testKnownHmacLengths()
+    {
+        Assertions.assertEquals(20, MacLengths.getMacLength("HMAC", "SHA-1"));
+        Assertions.assertEquals(20, MacLengths.getMacLength("HMAC", "SHA1"));
+        Assertions.assertEquals(28, MacLengths.getMacLength("HMAC", "SHA2-224"));
+        Assertions.assertEquals(32, MacLengths.getMacLength("HMAC", "SHA2-256"));
+        Assertions.assertEquals(48, MacLengths.getMacLength("HMAC", "SHA2-384"));
+        Assertions.assertEquals(64, MacLengths.getMacLength("HMAC", "SHA2-512"));
+        Assertions.assertEquals(28, MacLengths.getMacLength("HMAC", "SHA2-512/224"));
+        Assertions.assertEquals(32, MacLengths.getMacLength("HMAC", "SHA2-512/256"));
+        Assertions.assertEquals(28, MacLengths.getMacLength("HMAC", "SHA3-224"));
+        Assertions.assertEquals(32, MacLengths.getMacLength("HMAC", "SHA3-256"));
+        Assertions.assertEquals(48, MacLengths.getMacLength("HMAC", "SHA3-384"));
+        Assertions.assertEquals(64, MacLengths.getMacLength("HMAC", "SHA3-512"));
+        Assertions.assertEquals(16, MacLengths.getMacLength("HMAC", "MD5"));
+        Assertions.assertEquals(36, MacLengths.getMacLength("HMAC", "MD5-SHA1"));
+        Assertions.assertEquals(32, MacLengths.getMacLength("HMAC", "SM3"));
+        Assertions.assertEquals(20, MacLengths.getMacLength("HMAC", "RIPEMD-160"));
+    }
+
+    @Test
+    public void testKnownCmacLengths()
+    {
+        Assertions.assertEquals(16, MacLengths.getMacLength("CMAC", "aes-cbc"));
+    }
+
+    @Test
+    public void testUnknownMacLengthsUseNativeFallback()
+    {
+        Assertions.assertEquals(MacLengths.UNKNOWN_MAC_LENGTH, MacLengths.getMacLength("HMAC", null));
+        Assertions.assertEquals(MacLengths.UNKNOWN_MAC_LENGTH, MacLengths.getMacLength("HMAC", "SHAKE-128"));
+        Assertions.assertEquals(MacLengths.UNKNOWN_MAC_LENGTH, MacLengths.getMacLength("CMAC", "des-ede3-cbc"));
+        Assertions.assertEquals(MacLengths.UNKNOWN_MAC_LENGTH, MacLengths.getMacLength("KMAC", "SHAKE-128"));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSALengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSALengthsTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mldsa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+public class MLDSALengthsTest
+{
+    @Test
+    public void testKnownSignatureLengths()
+    {
+        Assertions.assertEquals(2420, MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_44, false));
+        Assertions.assertEquals(3309, MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_65, false));
+        Assertions.assertEquals(4627, MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_87, false));
+    }
+
+    @Test
+    public void testCalculateMuUsesNativeFallback()
+    {
+        Assertions.assertEquals(MLDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_44, true));
+        Assertions.assertEquals(MLDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_65, true));
+        Assertions.assertEquals(MLDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                MLDSALengths.getSignatureLength(OSSLKeyType.ML_DSA_87, true));
+    }
+
+    @Test
+    public void testUnknownSignatureLengthsUseNativeFallback()
+    {
+        Assertions.assertEquals(MLDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                MLDSALengths.getSignatureLength(null, false));
+        Assertions.assertEquals(MLDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                MLDSALengths.getSignatureLength(OSSLKeyType.ML_KEM_512, false));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMLengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMLengthsTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.mlkem;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+public class MLKEMLengthsTest
+{
+    @Test
+    public void testKnownEncapsulationLengths()
+    {
+        Assertions.assertEquals(768, MLKEMLengths.getEncapsulationLength(OSSLKeyType.ML_KEM_512));
+        Assertions.assertEquals(1088, MLKEMLengths.getEncapsulationLength(OSSLKeyType.ML_KEM_768));
+        Assertions.assertEquals(1568, MLKEMLengths.getEncapsulationLength(OSSLKeyType.ML_KEM_1024));
+    }
+
+    @Test
+    public void testUnknownEncapsulationLengthsUseNativeFallback()
+    {
+        Assertions.assertEquals(MLKEMLengths.UNKNOWN_ENCAPSULATION_LENGTH,
+                MLKEMLengths.getEncapsulationLength(null));
+        Assertions.assertEquals(MLKEMLengths.UNKNOWN_ENCAPSULATION_LENGTH,
+                MLKEMLengths.getEncapsulationLength(OSSLKeyType.ML_DSA_44));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSALengthsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSALengthsTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.slhdsa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.spec.OSSLKeyType;
+
+public class SLHDSALengthsTest
+{
+    @Test
+    public void testKnownSignatureLengths()
+    {
+        Assertions.assertEquals(7856, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_128s));
+        Assertions.assertEquals(7856, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_128s));
+        Assertions.assertEquals(17088, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_128f));
+        Assertions.assertEquals(17088, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_128f));
+        Assertions.assertEquals(16224, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_192s));
+        Assertions.assertEquals(16224, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_192s));
+        Assertions.assertEquals(35664, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_192f));
+        Assertions.assertEquals(35664, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_192f));
+        Assertions.assertEquals(29792, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_256s));
+        Assertions.assertEquals(29792, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_256s));
+        Assertions.assertEquals(49856, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHA2_256f));
+        Assertions.assertEquals(49856, SLHDSALengths.getSignatureLength(OSSLKeyType.SLH_DSA_SHAKE_256f));
+    }
+
+    @Test
+    public void testUnknownSignatureLengthsUseNativeFallback()
+    {
+        Assertions.assertEquals(SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                SLHDSALengths.getSignatureLength(null));
+        Assertions.assertEquals(SLHDSALengths.UNKNOWN_SIGNATURE_LENGTH,
+                SLHDSALengths.getSignatureLength(OSSLKeyType.ML_KEM_512));
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/mac/MacTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/mac/MacTest.java
@@ -330,6 +330,37 @@ public class MacTest
                 () -> Mac.getInstance("HmacUNKNOWN_FOOBAR", JostleProvider.PROVIDER_NAME));
     }
 
+    @Test
+    public void testGetMacLengthPerAlgorithm() throws Exception
+    {
+        Object[][] expected = new Object[][]{
+                {"HmacSHA1", 20},
+                {"HmacSHA224", 28},
+                {"HmacSHA256", 32},
+                {"HmacSHA384", 48},
+                {"HmacSHA512", 64},
+                {"HmacSHA512/224", 28},
+                {"HmacSHA512/256", 32},
+                {"HmacSHA3-224", 28},
+                {"HmacSHA3-256", 32},
+                {"HmacSHA3-384", 48},
+                {"HmacSHA3-512", 64},
+                {"HmacSM3", 32},
+                {"HmacMD5", 16},
+                {"HmacMD5SHA1", 36},
+                {"HmacRIPEMD160", 20},
+                {"AESCMAC", 16},
+        };
+
+        for (Object[] row : expected)
+        {
+            String name = (String) row[0];
+            int expectedLen = (Integer) row[1];
+            Mac mac = Mac.getInstance(name, JostleProvider.PROVIDER_NAME);
+            Assertions.assertEquals(expectedLen, mac.getMacLength(), "mac length for " + name);
+        }
+    }
+
 
     @Test
     public void testHmacMD5SHA1KnownVector() throws Exception


### PR DESCRIPTION
Avoids extra native calls for crypto sizes that are fixed by the algorithm, like AES block size, MAC length, and PQC signature/encapsulation sizes. Keeps native fallback for unknown or variable-size cases, so future algorithms or non-fixed paths still behave safely. Adds focused tests for the fixed-size tables and fallback behavior.