### PR TITLE
Basic X.509 Certfificate/CRL support, additional key processing, aliases, tests.

### DIFF
--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/AsymmetricKeyImpl.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/AsymmetricKeyImpl.java
@@ -32,4 +32,62 @@ public class AsymmetricKeyImpl
         return spec.getReference();
     }
 
+    /**
+     * Two keys are equal when their encoded forms match. Every concrete subclass
+     * implements {@link java.security.Key} (a public key encodes as X.509
+     * SubjectPublicKeyInfo, a private key as PKCS#8 PrivateKeyInfo), and the
+     * encoding embeds the algorithm OID — so encoding equality already implies
+     * same algorithm and same key role (public vs private). We deliberately do
+     * NOT compare {@code getAlgorithm()} strings, which are provider-specific
+     * (e.g. JSL reports "ML-DSA-44" where the JDK reports "ML-DSA").
+     *
+     * <p>Without this, JSL keys inherited identity equality, so two instances of
+     * the same key never compared equal — breaking callers that key collections
+     * on keys or sanity-check a parsed key against a certificate's key.
+     *
+     * <p>When either operand is a {@link java.security.PrivateKey} the encoded
+     * forms contain secret material, so the byte comparison is done with the
+     * constant-time {@link java.security.MessageDigest#isEqual} rather than
+     * {@link java.util.Arrays#equals} (which short-circuits on the first
+     * differing byte and would leak key material through timing).
+     */
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(this instanceof java.security.Key) || !(o instanceof java.security.Key))
+        {
+            return false;
+        }
+        byte[] mine = ((java.security.Key) this).getEncoded();
+        byte[] theirs = ((java.security.Key) o).getEncoded();
+        if (mine == null || theirs == null)
+        {
+            return false;
+        }
+        if (this instanceof java.security.PrivateKey || o instanceof java.security.PrivateKey)
+        {
+            // Constant-time: do not short-circuit on secret key material.
+            return java.security.MessageDigest.isEqual(mine, theirs);
+        }
+        return java.util.Arrays.equals(mine, theirs);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        if (this instanceof java.security.Key)
+        {
+            byte[] enc = ((java.security.Key) this).getEncoded();
+            if (enc != null)
+            {
+                return java.util.Arrays.hashCode(enc);
+            }
+        }
+        return System.identityHashCode(this);
+    }
+
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/AsymmetricKeyImpl.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/AsymmetricKeyImpl.java
@@ -12,6 +12,11 @@ package org.openssl.jostle.jcajce.provider;
 
 import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.PKEYKeySpec;
+import org.openssl.jostle.util.Arrays;
+
+import java.security.Key;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
 
 public class AsymmetricKeyImpl
 {
@@ -45,11 +50,11 @@ public class AsymmetricKeyImpl
      * the same key never compared equal — breaking callers that key collections
      * on keys or sanity-check a parsed key against a certificate's key.
      *
-     * <p>When either operand is a {@link java.security.PrivateKey} the encoded
-     * forms contain secret material, so the byte comparison is done with the
-     * constant-time {@link java.security.MessageDigest#isEqual} rather than
-     * {@link java.util.Arrays#equals} (which short-circuits on the first
-     * differing byte and would leak key material through timing).
+     * <p>When either operand is a {@link PrivateKey} the encoded forms contain
+     * secret material, so the byte comparison is done with the constant-time
+     * {@link MessageDigest#isEqual} rather than {@link Arrays#areEqual} (which
+     * short-circuits on the first differing byte and would leak key material
+     * through timing).
      */
     @Override
     public boolean equals(Object o)
@@ -58,33 +63,35 @@ public class AsymmetricKeyImpl
         {
             return true;
         }
-        if (!(this instanceof java.security.Key) || !(o instanceof java.security.Key))
+        if (!(this instanceof Key) || !(o instanceof Key))
         {
             return false;
         }
-        byte[] mine = ((java.security.Key) this).getEncoded();
-        byte[] theirs = ((java.security.Key) o).getEncoded();
+        byte[] mine = ((Key) this).getEncoded();
+        byte[] theirs = ((Key) o).getEncoded();
         if (mine == null || theirs == null)
         {
+            // Guard before areEqual: areEqual(null, null) is true, but two
+            // distinct keys whose encodings are unavailable must not be equal.
             return false;
         }
-        if (this instanceof java.security.PrivateKey || o instanceof java.security.PrivateKey)
+        if (this instanceof PrivateKey || o instanceof PrivateKey)
         {
             // Constant-time: do not short-circuit on secret key material.
-            return java.security.MessageDigest.isEqual(mine, theirs);
+            return MessageDigest.isEqual(mine, theirs);
         }
-        return java.util.Arrays.equals(mine, theirs);
+        return Arrays.areEqual(mine, theirs);
     }
 
     @Override
     public int hashCode()
     {
-        if (this instanceof java.security.Key)
+        if (this instanceof Key)
         {
-            byte[] enc = ((java.security.Key) this).getEncoded();
+            byte[] enc = ((Key) this).getEncoded();
             if (enc != null)
             {
-                return java.util.Arrays.hashCode(enc);
+                return Arrays.hashCode(enc);
             }
         }
         return System.identityHashCode(this);

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/JostleProvider.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/JostleProvider.java
@@ -100,6 +100,7 @@ public class JostleProvider
         new ProvRSA().configure(this);
         new ProvEC().configure(this);
         new ProvMac().configure(this);
+        new ProvX509().configure(this);
     }
 
     void addAttribute(String type, String name, String attributeName, String attributeValue)

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMD.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMD.java
@@ -89,7 +89,15 @@ public class ProvMD
             provider.addAlias("MessageDigest", name, keyAliasMap.get(name));
         }
 
-
+        //
+        // Fixed-output SHAKE variants. BouncyCastle's CMS/PKIX layer requests these
+        // by name (e.g. JcaDigestCalculatorProviderBuilder for SHA3 / ML-DSA signer
+        // info), treating SHAKE as a plain hash squeezed to a fixed length. OpenSSL
+        // has no digest with these names, so map them onto the SHAKE-128 / SHAKE-256
+        // primitives with the corresponding fixed XOF output length (256 / 512 bits).
+        //
+        provider.addAlgorithmImplementation("MessageDigest", "SHAKE128-256", PREFIX + "MDServiceSPI$SHAKE128_256", attr, (arg) -> new MDServiceSPI("SHAKE-128", 32));
+        provider.addAlgorithmImplementation("MessageDigest", "SHAKE256-512", PREFIX + "MDServiceSPI$SHAKE256_512", attr, (arg) -> new MDServiceSPI("SHAKE-256", 64));
     }
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvRSA.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvRSA.java
@@ -67,6 +67,22 @@ class ProvRSA
                 (arg) -> new RSAPSSSignatureSpi());
         provider.addAlias("Signature", "RSASSA-PSS", "1.2.840.113549.1.1.10");
 
+        // Per-digest RSASSA-PSS convenience names. BouncyCastle's PKIX/CMS layer
+        // derives "<digest>WITHRSAANDMGF1" from an id-RSASSA-PSS AlgorithmIdentifier
+        // (with "<digest>WITHRSASSA-PSS" as the fallback name) and, for default PSS
+        // parameters, does NOT call setParameter — so each name must carry its own
+        // digest default (with MGF1 over the same hash). Non-default parameters are
+        // still applied via engineSetParameter, overriding the name's default.
+        registerPssSignature(provider, attr, "SHA1", "SHA-1");
+        registerPssSignature(provider, attr, "SHA224", "SHA-224");
+        registerPssSignature(provider, attr, "SHA256", "SHA-256");
+        registerPssSignature(provider, attr, "SHA384", "SHA-384");
+        registerPssSignature(provider, attr, "SHA512", "SHA-512");
+        registerPssSignature(provider, attr, "SHA3-224", "SHA3-224");
+        registerPssSignature(provider, attr, "SHA3-256", "SHA3-256");
+        registerPssSignature(provider, attr, "SHA3-384", "SHA3-384");
+        registerPssSignature(provider, attr, "SHA3-512", "SHA3-512");
+
         // RSA-OAEP cipher. The provider registers only the bare "RSA"
         // primary; transformation strings like
         //   "RSA/ECB/OAEPPadding"
@@ -97,6 +113,27 @@ class ProvRSA
                 PREFIX + "RSAPKCS1CipherSpi", pkcs1Attr,
                 (arg) -> new RSAPKCS1CipherSpi());
         provider.addAlias("Cipher", "RSA/ECB/PKCS1Padding", "RSA/None/PKCS1Padding");
+    }
+
+    /**
+     * Register a {@code <digest>WITHRSAANDMGF1} PSS Signature whose digest (and
+     * MGF1 hash) default to {@code opensslDigest}, plus the equivalent
+     * {@code <digest>WITHRSASSA-PSS} alias.
+     */
+    private static void registerPssSignature(JostleProvider provider,
+                                             Map<String, String> attr,
+                                             String digestJcaName,
+                                             String opensslDigest)
+    {
+        String mgf1Name = digestJcaName + "WITHRSAANDMGF1";
+        // Unique creatorMap key per digest (the map is keyed by this class-name
+        // string; reusing the bare SPI name collides with the generic RSASSA-PSS
+        // registration and the other per-digest entries).
+        String implName = PREFIX + "RSAPSSSignatureSpi$" + digestJcaName.replace("-", "_");
+        provider.addAlgorithmImplementation("Signature", mgf1Name,
+                implName, attr,
+                (arg) -> new RSAPSSSignatureSpi(opensslDigest));
+        provider.addAlias("Signature", mgf1Name, digestJcaName + "WITHRSASSA-PSS");
     }
 
     private static void registerPkcs1Signature(JostleProvider provider,

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvX509.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvX509.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider;
+
+import org.openssl.jostle.jcajce.provider.cert.X509CertificateFactorySpi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class ProvX509
+{
+    private static final String PREFIX = ProvX509.class.getPackage().getName() + ".cert.";
+
+    public void configure(final JostleProvider provider)
+    {
+        final Map<String, String> attr = new HashMap<String, String>();
+        provider.addAlgorithmImplementation("CertificateFactory", "X.509", PREFIX + "X509CertificateFactorySpi", attr, (arg) -> new X509CertificateFactorySpi());
+        provider.addAlias("CertificateFactory", "X.509", "X509");
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.cert;
+
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Wraps a JDK-parsed {@link X509Certificate} and re-derives its public key through
+ * the JSL provider's KeyFactory, so that JSL's Signature SPIs (which require their
+ * own key types) accept the certificate's public key. Everything else delegates to
+ * the wrapped certificate.
+ */
+class JSLKeyX509Certificate
+    extends X509Certificate
+{
+    private final X509Certificate delegate;
+    private final String providerName;
+
+    JSLKeyX509Certificate(X509Certificate delegate, String providerName)
+    {
+        this.delegate = delegate;
+        this.providerName = providerName;
+    }
+
+    public PublicKey getPublicKey()
+    {
+        PublicKey key = delegate.getPublicKey();
+        try
+        {
+            KeyFactory kf = KeyFactory.getInstance(key.getAlgorithm(), providerName);
+            return kf.generatePublic(new X509EncodedKeySpec(key.getEncoded()));
+        }
+        catch (NoSuchAlgorithmException | NoSuchProviderException | java.security.spec.InvalidKeySpecException e)
+        {
+            // The JSL provider has no KeyFactory for this algorithm (or can't import
+            // it); fall back to the JDK-provided key.
+            return key;
+        }
+    }
+
+    // --- everything else delegates ---
+
+    public void checkValidity()
+        throws CertificateExpiredException, CertificateNotYetValidException
+    {
+        delegate.checkValidity();
+    }
+
+    public void checkValidity(Date date)
+        throws CertificateExpiredException, CertificateNotYetValidException
+    {
+        delegate.checkValidity(date);
+    }
+
+    public int getVersion()
+    {
+        return delegate.getVersion();
+    }
+
+    public java.math.BigInteger getSerialNumber()
+    {
+        return delegate.getSerialNumber();
+    }
+
+    public Principal getIssuerDN()
+    {
+        return delegate.getIssuerDN();
+    }
+
+    public Principal getSubjectDN()
+    {
+        return delegate.getSubjectDN();
+    }
+
+    public javax.security.auth.x500.X500Principal getIssuerX500Principal()
+    {
+        return delegate.getIssuerX500Principal();
+    }
+
+    public javax.security.auth.x500.X500Principal getSubjectX500Principal()
+    {
+        return delegate.getSubjectX500Principal();
+    }
+
+    public Date getNotBefore()
+    {
+        return delegate.getNotBefore();
+    }
+
+    public Date getNotAfter()
+    {
+        return delegate.getNotAfter();
+    }
+
+    public byte[] getTBSCertificate()
+        throws CertificateEncodingException
+    {
+        return delegate.getTBSCertificate();
+    }
+
+    public byte[] getSignature()
+    {
+        return delegate.getSignature();
+    }
+
+    public String getSigAlgName()
+    {
+        return delegate.getSigAlgName();
+    }
+
+    public String getSigAlgOID()
+    {
+        return delegate.getSigAlgOID();
+    }
+
+    public byte[] getSigAlgParams()
+    {
+        return delegate.getSigAlgParams();
+    }
+
+    public boolean[] getIssuerUniqueID()
+    {
+        return delegate.getIssuerUniqueID();
+    }
+
+    public boolean[] getSubjectUniqueID()
+    {
+        return delegate.getSubjectUniqueID();
+    }
+
+    public boolean[] getKeyUsage()
+    {
+        return delegate.getKeyUsage();
+    }
+
+    public List<String> getExtendedKeyUsage()
+        throws CertificateParsingException
+    {
+        return delegate.getExtendedKeyUsage();
+    }
+
+    public int getBasicConstraints()
+    {
+        return delegate.getBasicConstraints();
+    }
+
+    public Collection<List<?>> getSubjectAlternativeNames()
+        throws CertificateParsingException
+    {
+        return delegate.getSubjectAlternativeNames();
+    }
+
+    public Collection<List<?>> getIssuerAlternativeNames()
+        throws CertificateParsingException
+    {
+        return delegate.getIssuerAlternativeNames();
+    }
+
+    public byte[] getEncoded()
+        throws CertificateEncodingException
+    {
+        return delegate.getEncoded();
+    }
+
+    public void verify(PublicKey key)
+        throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException
+    {
+        delegate.verify(key);
+    }
+
+    public void verify(PublicKey key, String sigProvider)
+        throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException
+    {
+        delegate.verify(key, sigProvider);
+    }
+
+    public String toString()
+    {
+        return delegate.toString();
+    }
+
+    // --- X509Extension ---
+
+    public boolean hasUnsupportedCriticalExtension()
+    {
+        return delegate.hasUnsupportedCriticalExtension();
+    }
+
+    public Set<String> getCriticalExtensionOIDs()
+    {
+        return delegate.getCriticalExtensionOIDs();
+    }
+
+    public Set<String> getNonCriticalExtensionOIDs()
+    {
+        return delegate.getNonCriticalExtensionOIDs();
+    }
+
+    public byte[] getExtensionValue(String oid)
+    {
+        return delegate.getExtensionValue(oid);
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
@@ -15,6 +15,7 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Principal;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
@@ -195,6 +196,19 @@ class JSLKeyX509Certificate
 
     public void verify(PublicKey key, String sigProvider)
         throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException
+    {
+        delegate.verify(key, sigProvider);
+    }
+
+    /**
+     * Provider-instance overload (no {@code NoSuchProviderException}, since the
+     * provider is supplied directly). The base {@link java.security.cert.Certificate}
+     * default throws {@code UnsupportedOperationException}, so this must be
+     * overridden to delegate — otherwise callers that pass a {@link Provider}
+     * instance (rather than a provider name) break against the wrapped cert.
+     */
+    public void verify(PublicKey key, Provider sigProvider)
+        throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, SignatureException
     {
         delegate.verify(key, sigProvider);
     }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.cert;
+
+import java.io.InputStream;
+import java.security.NoSuchProviderException;
+import java.security.cert.CRL;
+import java.security.cert.CRLException;
+import java.security.cert.CertPath;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateFactorySpi;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+/**
+ * X.509 CertificateFactory for the JSL provider.
+ *
+ * <p>Parsing X.509 certificates / CRLs / CertPaths is ASN.1 structure work, not a
+ * cryptographic operation, so this delegates to the JDK's built-in "SUN" X.509
+ * factory rather than re-implementing it. It exists so that consumers (notably the
+ * PKIX/CMS layer's {@code JcaX509CertificateConverter} and the various
+ * {@code setProvider("JSL")} helpers) can resolve {@code CertificateFactory.X.509}
+ * against the JSL provider.</p>
+ *
+ * <p>The delegate is fetched explicitly from the {@code SUN} provider to avoid
+ * recursing back into this factory if JSL happens to be highest in the provider
+ * search order.</p>
+ */
+public class X509CertificateFactorySpi
+    extends CertificateFactorySpi
+{
+    private final CertificateFactory delegate;
+
+    public X509CertificateFactorySpi()
+    {
+        try
+        {
+            this.delegate = CertificateFactory.getInstance("X.509", "SUN");
+        }
+        catch (CertificateException | NoSuchProviderException e)
+        {
+            throw new IllegalStateException("unable to obtain a JDK X.509 CertificateFactory: " + e.getMessage(), e);
+        }
+    }
+
+    public Certificate engineGenerateCertificate(InputStream inStream)
+        throws CertificateException
+    {
+        return wrap(delegate.generateCertificate(inStream));
+    }
+
+    public Collection<? extends Certificate> engineGenerateCertificates(InputStream inStream)
+        throws CertificateException
+    {
+        Collection<? extends Certificate> certs = delegate.generateCertificates(inStream);
+        List<Certificate> wrapped = new ArrayList<Certificate>(certs.size());
+        for (Certificate c : certs)
+        {
+            wrapped.add(wrap(c));
+        }
+        return wrapped;
+    }
+
+    /**
+     * Re-wrap an X.509 certificate so its getPublicKey() returns a JSL-provider key
+     * (JSL Signature SPIs require their own key types). Non-X.509 results pass through.
+     */
+    private static Certificate wrap(Certificate c)
+    {
+        if (c instanceof X509Certificate)
+        {
+            return new JSLKeyX509Certificate((X509Certificate) c, JostleProvider.PROVIDER_NAME);
+        }
+        return c;
+    }
+
+    public CRL engineGenerateCRL(InputStream inStream)
+        throws CRLException
+    {
+        return delegate.generateCRL(inStream);
+    }
+
+    public Collection<? extends CRL> engineGenerateCRLs(InputStream inStream)
+        throws CRLException
+    {
+        return delegate.generateCRLs(inStream);
+    }
+
+    public CertPath engineGenerateCertPath(InputStream inStream)
+        throws CertificateException
+    {
+        return delegate.generateCertPath(inStream);
+    }
+
+    public CertPath engineGenerateCertPath(InputStream inStream, String encoding)
+        throws CertificateException
+    {
+        return delegate.generateCertPath(inStream, encoding);
+    }
+
+    public CertPath engineGenerateCertPath(List<? extends Certificate> certificates)
+        throws CertificateException
+    {
+        return delegate.generateCertPath(certificates);
+    }
+
+    public java.util.Iterator<String> engineGetCertPathEncodings()
+    {
+        return delegate.getCertPathEncodings();
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
@@ -58,21 +58,64 @@ public class ECDSASignatureSpi extends SignatureSpi
     }
 
 
+    /**
+     * Coerce an arbitrary public key to a JSL EC public key. JSL keys are
+     * used directly; foreign EC keys (e.g. a {@code sun.*} key from a
+     * JDK-parsed certificate, as the CMS/PKIX verifiers hand us) are
+     * re-imported through {@link ECKeyFactorySpi#engineTranslateKey} so
+     * external callers interoperate without having to pre-convert keys.
+     * Anything that isn't EC surfaces as {@link InvalidKeyException}.
+     */
+    private static JOECPublicKey importPublic(PublicKey publicKey) throws InvalidKeyException
+    {
+        if (publicKey instanceof JOECPublicKey)
+        {
+            return (JOECPublicKey) publicKey;
+        }
+        try
+        {
+            Key translated = new ECKeyFactorySpi().engineTranslateKey(publicKey);
+            if (translated instanceof JOECPublicKey)
+            {
+                return (JOECPublicKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an ECPublicKey from the Jostle provider");
+    }
+
+    /** Private-key counterpart to {@link #importPublic}. */
+    private static JOECPrivateKey importPrivate(PrivateKey privateKey) throws InvalidKeyException
+    {
+        if (privateKey instanceof JOECPrivateKey)
+        {
+            return (JOECPrivateKey) privateKey;
+        }
+        try
+        {
+            Key translated = new ECKeyFactorySpi().engineTranslateKey(privateKey);
+            if (translated instanceof JOECPrivateKey)
+            {
+                return (JOECPrivateKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an ECPrivateKey from the Jostle provider");
+    }
+
+
     @Override
     protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException
     {
         synchronized (this)
         {
-            if (!(publicKey instanceof ECPublicKey))
-            {
-                throw new InvalidKeyException("expected an ECPublicKey from the Jostle provider");
-            }
-            if (!(publicKey instanceof JOECPublicKey))
-            {
-                throw new InvalidKeyException("expected a Jostle-provider ECPublicKey");
-            }
-
-            JOECPublicKey key = (JOECPublicKey) publicKey;
+            JOECPublicKey key = importPublic(publicKey);
             lastKey = key;
 
             ensureRef();
@@ -93,16 +136,7 @@ public class ECDSASignatureSpi extends SignatureSpi
 
         synchronized (this)
         {
-            if (!(privateKey instanceof ECPrivateKey))
-            {
-                throw new InvalidKeyException("expected an ECPrivateKey from the Jostle provider");
-            }
-            if (!(privateKey instanceof JOECPrivateKey))
-            {
-                throw new InvalidKeyException("expected a Jostle-provider ECPrivateKey");
-            }
-
-            JOECPrivateKey key = (JOECPrivateKey) privateKey;
+            JOECPrivateKey key = importPrivate(privateKey);
             lastKey = key;
 
             ensureRef();

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOPBEKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOPBEKey.java
@@ -18,7 +18,9 @@ import javax.crypto.interfaces.PBEKey;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 import java.io.Serializable;
+import java.security.MessageDigest;
 import java.security.spec.KeySpec;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class JOPBEKey implements PBEKey, KeySpec, SecretKey, Destroyable, Serializable
@@ -105,5 +107,36 @@ class JOPBEKey implements PBEKey, KeySpec, SecretKey, Destroyable, Serializable
         {
             throw new IllegalStateException("key has been destroyed");
         }
+    }
+
+    /**
+     * Value equality following the {@code javax.crypto.spec.SecretKeySpec} contract:
+     * same algorithm (case-insensitive) and same raw key bytes. The byte comparison
+     * uses the constant-time {@link MessageDigest#isEqual} because the raw key is
+     * secret material (a non-constant-time compare would leak it via timing).
+     */
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof SecretKey))
+        {
+            return false;
+        }
+        SecretKey other = (SecretKey) o;
+        if (!algoName.equalsIgnoreCase(other.getAlgorithm()))
+        {
+            return false;
+        }
+        return MessageDigest.isEqual(rawKey, other.getEncoded());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return java.util.Arrays.hashCode(rawKey) ^ algoName.toLowerCase(Locale.ROOT).hashCode();
     }
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOScryptKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOScryptKey.java
@@ -17,7 +17,9 @@ import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 import java.io.Serializable;
+import java.security.MessageDigest;
 import java.security.spec.KeySpec;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class JOScryptKey implements KeySpec, SecretKey, Destroyable, Serializable
@@ -124,5 +126,36 @@ class JOScryptKey implements KeySpec, SecretKey, Destroyable, Serializable
         {
             throw new IllegalStateException("key has been destroyed");
         }
+    }
+
+    /**
+     * Value equality following the {@code javax.crypto.spec.SecretKeySpec} contract:
+     * same algorithm (case-insensitive) and same raw key bytes. The byte comparison
+     * uses the constant-time {@link MessageDigest#isEqual} because the raw key is
+     * secret material (a non-constant-time compare would leak it via timing).
+     */
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof SecretKey))
+        {
+            return false;
+        }
+        SecretKey other = (SecretKey) o;
+        if (!algoName.equalsIgnoreCase(other.getAlgorithm()))
+        {
+            return false;
+        }
+        return MessageDigest.isEqual(rawKey, other.getEncoded());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return java.util.Arrays.hashCode(rawKey) ^ algoName.toLowerCase(Locale.ROOT).hashCode();
     }
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAPSSSignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAPSSSignatureSpi.java
@@ -50,6 +50,21 @@ public class RSAPSSSignatureSpi extends RSASignatureSpiBase
 
     public RSAPSSSignatureSpi() {}
 
+    /**
+     * Per-digest constructor for the named {@code SHAxxxWITHRSAANDMGF1} /
+     * {@code SHAxxxWITHRSASSA-PSS} convenience algorithms, where the digest is
+     * implied by the algorithm name. Defaults MGF1 to the same hash and the
+     * salt length to the digest output length, matching PKCS#1 v2.2 practice.
+     * If the caller subsequently supplies a {@link PSSParameterSpec} (as the
+     * PKIX layer does for non-default parameters) it overrides these.
+     */
+    public RSAPSSSignatureSpi(String digest)
+    {
+        this.digestName = digest;
+        this.mgf1Digest = digest;
+        this.saltLen = -1;
+    }
+
     @Override
     protected void engineSetParameter(AlgorithmParameterSpec params) throws InvalidAlgorithmParameterException
     {

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpiBase.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpiBase.java
@@ -24,6 +24,7 @@ import org.openssl.jostle.rand.DefaultRandSource;
 import org.openssl.jostle.rand.RandSource;
 
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -57,20 +58,67 @@ abstract class RSASignatureSpiBase extends SignatureSpi
     protected abstract void nativeInitVerify(long ref, long keyRef);
 
 
+    /**
+     * Coerce an arbitrary public key to a JSL RSA public key. JSL keys are
+     * used directly; foreign RSA keys (e.g. a {@code sun.*} key from a
+     * JDK-parsed certificate, as the CMS/PKIX verifiers hand us) are
+     * re-imported through {@link RSAKeyFactorySpi#engineTranslateKey} so
+     * external callers interoperate without having to pre-convert keys.
+     * Anything that isn't RSA surfaces as {@link InvalidKeyException}.
+     */
+    private static JORSAPublicKey importPublic(PublicKey publicKey) throws InvalidKeyException
+    {
+        if (publicKey instanceof JORSAPublicKey)
+        {
+            return (JORSAPublicKey) publicKey;
+        }
+        try
+        {
+            Key translated = new RSAKeyFactorySpi().engineTranslateKey(publicKey);
+            if (translated instanceof JORSAPublicKey)
+            {
+                return (JORSAPublicKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an RSAPublicKey from the Jostle provider");
+    }
+
+    /** Private-key counterpart to {@link #importPublic}. */
+    private static JORSAPrivateKey importPrivate(PrivateKey privateKey) throws InvalidKeyException
+    {
+        if (privateKey instanceof JORSAPrivateKey)
+        {
+            return (JORSAPrivateKey) privateKey;
+        }
+        try
+        {
+            Key translated = new RSAKeyFactorySpi().engineTranslateKey(privateKey);
+            if (translated instanceof JORSAPrivateKey)
+            {
+                return (JORSAPrivateKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an RSAPrivateKey from the Jostle provider");
+    }
+
+
     @Override
     protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException
     {
         synchronized (this)
         {
-            if (!(publicKey instanceof RSAPublicKey))
-            {
-                throw new InvalidKeyException("expected an RSAPublicKey from the Jostle provider");
-            }
-
-            JORSAPublicKey key = (JORSAPublicKey) publicKey;
+            JORSAPublicKey key = importPublic(publicKey);
             lastKey = key;
 
-            ensureRef(publicKey.getAlgorithm());
+            ensureRef(key.getAlgorithm());
             nativeInitVerify(ref.getReference(), key.getSpec().getReference());
         }
     }
@@ -88,15 +136,10 @@ abstract class RSASignatureSpiBase extends SignatureSpi
 
         synchronized (this)
         {
-            if (!(privateKey instanceof RSAPrivateKey))
-            {
-                throw new InvalidKeyException("expected an RSAPrivateKey from the Jostle provider");
-            }
-
-            JORSAPrivateKey key = (JORSAPrivateKey) privateKey;
+            JORSAPrivateKey key = importPrivate(privateKey);
             lastKey = key;
 
-            ensureRef(privateKey.getAlgorithm());
+            ensureRef(key.getAlgorithm());
             nativeInitSign(ref.getReference(), key.getSpec().getReference(), randSource);
         }
     }

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
@@ -21,6 +21,7 @@ import org.openssl.jostle.rand.RandSource;
 
 import java.lang.ref.Reference;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -55,21 +56,64 @@ public class ECDSASignatureSpi extends SignatureSpi
     }
 
 
+    /**
+     * Coerce an arbitrary public key to a JSL EC public key. JSL keys are
+     * used directly; foreign EC keys (e.g. a {@code sun.*} key from a
+     * JDK-parsed certificate, as the CMS/PKIX verifiers hand us) are
+     * re-imported through {@link ECKeyFactorySpi#engineTranslateKey} so
+     * external callers interoperate without having to pre-convert keys.
+     * Anything that isn't EC surfaces as {@link InvalidKeyException}.
+     */
+    private static JOECPublicKey importPublic(PublicKey publicKey) throws InvalidKeyException
+    {
+        if (publicKey instanceof JOECPublicKey)
+        {
+            return (JOECPublicKey) publicKey;
+        }
+        try
+        {
+            Key translated = new ECKeyFactorySpi().engineTranslateKey(publicKey);
+            if (translated instanceof JOECPublicKey)
+            {
+                return (JOECPublicKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an ECPublicKey from the Jostle provider");
+    }
+
+    /** Private-key counterpart to {@link #importPublic}. */
+    private static JOECPrivateKey importPrivate(PrivateKey privateKey) throws InvalidKeyException
+    {
+        if (privateKey instanceof JOECPrivateKey)
+        {
+            return (JOECPrivateKey) privateKey;
+        }
+        try
+        {
+            Key translated = new ECKeyFactorySpi().engineTranslateKey(privateKey);
+            if (translated instanceof JOECPrivateKey)
+            {
+                return (JOECPrivateKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an ECPrivateKey from the Jostle provider");
+    }
+
+
     @Override
     protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException
     {
         try
         {
-            if (!(publicKey instanceof ECPublicKey))
-            {
-                throw new InvalidKeyException("expected an ECPublicKey from the Jostle provider");
-            }
-            if (!(publicKey instanceof JOECPublicKey))
-            {
-                throw new InvalidKeyException("expected a Jostle-provider ECPublicKey");
-            }
-
-            JOECPublicKey key = (JOECPublicKey) publicKey;
+            JOECPublicKey key = importPublic(publicKey);
             lastKey = key;
 
             ensureRef();
@@ -94,16 +138,7 @@ public class ECDSASignatureSpi extends SignatureSpi
 
         try
         {
-            if (!(privateKey instanceof ECPrivateKey))
-            {
-                throw new InvalidKeyException("expected an ECPrivateKey from the Jostle provider");
-            }
-            if (!(privateKey instanceof JOECPrivateKey))
-            {
-                throw new InvalidKeyException("expected a Jostle-provider ECPrivateKey");
-            }
-
-            JOECPrivateKey key = (JOECPrivateKey) privateKey;
+            JOECPrivateKey key = importPrivate(privateKey);
             lastKey = key;
 
             ensureRef();

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpiBase.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpiBase.java
@@ -24,6 +24,7 @@ import org.openssl.jostle.rand.RandSource;
 
 import java.lang.ref.Reference;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -62,20 +63,67 @@ abstract class RSASignatureSpiBase extends SignatureSpi
     protected abstract void nativeInitVerify(long ref, long keyRef);
 
 
+    /**
+     * Coerce an arbitrary public key to a JSL RSA public key. JSL keys are
+     * used directly; foreign RSA keys (e.g. a {@code sun.*} key from a
+     * JDK-parsed certificate, as the CMS/PKIX verifiers hand us) are
+     * re-imported through {@link RSAKeyFactorySpi#engineTranslateKey} so
+     * external callers interoperate without having to pre-convert keys.
+     * Anything that isn't RSA surfaces as {@link InvalidKeyException}.
+     */
+    private static JORSAPublicKey importPublic(PublicKey publicKey) throws InvalidKeyException
+    {
+        if (publicKey instanceof JORSAPublicKey)
+        {
+            return (JORSAPublicKey) publicKey;
+        }
+        try
+        {
+            Key translated = new RSAKeyFactorySpi().engineTranslateKey(publicKey);
+            if (translated instanceof JORSAPublicKey)
+            {
+                return (JORSAPublicKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an RSAPublicKey from the Jostle provider");
+    }
+
+    /** Private-key counterpart to {@link #importPublic}. */
+    private static JORSAPrivateKey importPrivate(PrivateKey privateKey) throws InvalidKeyException
+    {
+        if (privateKey instanceof JORSAPrivateKey)
+        {
+            return (JORSAPrivateKey) privateKey;
+        }
+        try
+        {
+            Key translated = new RSAKeyFactorySpi().engineTranslateKey(privateKey);
+            if (translated instanceof JORSAPrivateKey)
+            {
+                return (JORSAPrivateKey) translated;
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            // Wrong-algorithm or unparseable key — fall through to the canonical message.
+        }
+        throw new InvalidKeyException("expected an RSAPrivateKey from the Jostle provider");
+    }
+
+
     @Override
     protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException
     {
         try
         {
-            if (!(publicKey instanceof RSAPublicKey))
-            {
-                throw new InvalidKeyException("expected an RSAPublicKey from the Jostle provider");
-            }
-
-            JORSAPublicKey key = (JORSAPublicKey) publicKey;
+            JORSAPublicKey key = importPublic(publicKey);
             lastKey = key;
 
-            ensureRef(publicKey.getAlgorithm());
+            ensureRef(key.getAlgorithm());
             nativeInitVerify(ref.getReference(), key.getSpec().getReference());
         }
         finally
@@ -97,15 +145,10 @@ abstract class RSASignatureSpiBase extends SignatureSpi
 
         try
         {
-            if (!(privateKey instanceof RSAPrivateKey))
-            {
-                throw new InvalidKeyException("expected an RSAPrivateKey from the Jostle provider");
-            }
-
-            JORSAPrivateKey key = (JORSAPrivateKey) privateKey;
+            JORSAPrivateKey key = importPrivate(privateKey);
             lastKey = key;
 
-            ensureRef(privateKey.getAlgorithm());
+            ensureRef(key.getAlgorithm());
             nativeInitSign(ref.getReference(), key.getSpec().getReference(), randSource);
         }
         finally

--- a/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
@@ -18,6 +18,7 @@ import org.openssl.jostle.jcajce.provider.JostleProvider;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
@@ -224,6 +225,18 @@ public class X509CertificateFactoryTest
         verifier2.update(tamperedTbs);
         Assertions.assertFalse(verifier2.verify(sig),
                 cert.getSigAlgName() + ": tampered TBS unexpectedly verified");
+    }
+
+    @Test
+    public void testVerify_withProviderInstance_overload() throws Exception
+    {
+        // The verify(PublicKey, Provider) overload must delegate to the wrapped
+        // cert, NOT fall through to Certificate's default (which throws
+        // UnsupportedOperationException). Self-signed cert → verifies against its
+        // own JSL public key when handed the JSL Provider instance.
+        X509Certificate cert = parse(rsaCertDer());
+        Provider jsl = Security.getProvider(JostleProvider.PROVIDER_NAME);
+        cert.verify(cert.getPublicKey(), jsl); // must not throw
     }
 
     // -----------------------------------------------------------------

--- a/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
@@ -1,0 +1,316 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.cert;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.Signature;
+import java.security.cert.CertPath;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509CRL;
+import java.security.cert.X509CRLEntry;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * JCE-level tests for the JSL {@code CertificateFactory.X.509} SPI
+ * ({@code X509CertificateFactorySpi} + {@code JSLKeyX509Certificate}).
+ *
+ * <p>The factory delegates the ASN.1 parsing to the JDK "SUN" factory but
+ * re-wraps each {@link X509Certificate} so that {@code getPublicKey()} returns
+ * a JSL-provider key usable directly in JSL's Signature SPIs. These tests
+ * confirm:
+ * <ol>
+ *   <li>the factory resolves against the JSL provider by both "X.509" and the
+ *       "X509" alias,</li>
+ *   <li>{@code getPublicKey()} returns a JSL key (not the SUN key) for both RSA
+ *       and EC certificates,</li>
+ *   <li>that JSL key actually verifies the certificate's own (self-signed)
+ *       signature through a JSL {@link Signature} — and a tampered TBS does
+ *       NOT verify (negative path),</li>
+ *   <li>the bulk {@code generateCertificates} and {@code generateCertPath}
+ *       entry points round-trip.</li>
+ * </ol>
+ *
+ * <p>The two test certificates are self-signed leaves generated offline with
+ * OpenSSL (SHA256withRSA / SHA256withECDSA) and embedded as base64 DER so the
+ * test needs no PKIX cert-builder dependency (only bcprov is on the test
+ * classpath).
+ */
+public class X509CertificateFactoryTest
+{
+    // Self-signed 2048-bit RSA cert, sha256WithRSAEncryption.
+    private static final String RSA_CERT_B64 =
+            "MIIDFTCCAf2gAwIBAgIUVSbA2ohOLE8j05vqRp0HoFCgcYcwDQYJKoZIhvcNAQEL"
+          + "BQAwGjEYMBYGA1UEAwwPSm9zdGxlIFJTQSBUZXN0MB4XDTI2MDYwNTIzNTA1NloX"
+          + "DTM2MDYwMjIzNTA1NlowGjEYMBYGA1UEAwwPSm9zdGxlIFJTQSBUZXN0MIIBIjAN"
+          + "BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtA9sLfgO1/dW9q1w/dyoox6S0C6l"
+          + "fWYIwtr+kiuJicBfQ+0Bqm1XRqVhmLUTSadxLMbEY+rQ0Hyq0YNQrgKME68pbX1k"
+          + "FQcNk3aS/a+aJ7J2XG/yZih5rHhgxKIjaGDfsBdQPlTueC8IV+3v+h8SweYuOv5y"
+          + "aXKcxk+IeN/MzSag/2YqDsBzmN98R0hAGvvVsU9KN6OydTSqDAGJ0ontBoJmqj3N"
+          + "5bdwImikjVSYC65frTMcvFgO2gOrRHiMCuqxhR0wLhn2AZote/LdUMIrIhB2wMOQ"
+          + "1NiIN1jET8TN9FSVDXjlK+MFRWopx8rdtg3h7Egs1U6WsBQ8jOTQIASm1wIDAQAB"
+          + "o1MwUTAdBgNVHQ4EFgQUTlapRpnUiPa9hzCribOp+lqpScgwHwYDVR0jBBgwFoAU"
+          + "TlapRpnUiPa9hzCribOp+lqpScgwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0B"
+          + "AQsFAAOCAQEAIS/foqm1TkS68DNfElAWhaabpP8/TBpNF5VTYgMHp9H/NGprGUm5"
+          + "DXngGRQgN7WwsJVhuhJJP58qGOVjsuZlwXhN/65l3xDof9JuEAeGGJKkfJZfaF3b"
+          + "6mDVlM2m3VCNcCRiuJqllDy/L6/D3t5WFxSizDGM4gYObX3tFnm4keiEohE2gZ8+"
+          + "KpudoyLOnsEBxBO/Xv9+cQlfkoU7Pd6N+bDZ6HpoDkFp29iVxtRhPign+5HAl03J"
+          + "4BVccBXua58I57YzhfP1YDD1DKK8H3SKzaHTrUkZBZkvAEvmIkOKIIOvJRjkXGlA"
+          + "V806dyTKN7aECu5CPJLm9ZlxyuBPFTBE0w==";
+
+    // Self-signed P-256 EC cert, ecdsa-with-SHA256.
+    private static final String EC_CERT_B64 =
+            "MIIBhzCCAS2gAwIBAgIUGw7BX327g5VGgIB0kLh4b3d/cEYwCgYIKoZIzj0EAwIw"
+          + "GTEXMBUGA1UEAwwOSm9zdGxlIEVDIFRlc3QwHhcNMjYwNjA1MjM1MDU2WhcNMzYw"
+          + "NjAyMjM1MDU2WjAZMRcwFQYDVQQDDA5Kb3N0bGUgRUMgVGVzdDBZMBMGByqGSM49"
+          + "AgEGCCqGSM49AwEHA0IABJ3IIptnXEpqnBxrqPNim2tasxMlp4i+KuGDUwVLXXA5"
+          + "kostunyWLXe+/HYJLhOuFZH3SSQuqaQuPlk3MHurxM2jUzBRMB0GA1UdDgQWBBQt"
+          + "H9lYOOYWHAQ02wUzpkQnF59FuzAfBgNVHSMEGDAWgBQtH9lYOOYWHAQ02wUzpkQn"
+          + "F59FuzAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIHQ6mpnH9ACV"
+          + "LTlGJzOeeVi7bAbb+sshOBe8yU70hIW+AiEA1Pdbej87xccBxO1vrWs+/Kul3Y2q"
+          + "jIWEouTwpbn+V60=";
+
+    // Self-signed CA cert (CN=Jostle Test CA) that signed the CRL below.
+    private static final String CA_CERT_B64 =
+            "MIIDEzCCAfugAwIBAgIUVl1zlM3b8O5ShxK+m8azHpi1TtwwDQYJKoZIhvcNAQEL"
+          + "BQAwGTEXMBUGA1UEAwwOSm9zdGxlIFRlc3QgQ0EwHhcNMjYwNjA2MDAxMDQ4WhcN"
+          + "MzYwNjAzMDAxMDQ4WjAZMRcwFQYDVQQDDA5Kb3N0bGUgVGVzdCBDQTCCASIwDQYJ"
+          + "KoZIhvcNAQEBBQADggEPADCCAQoCggEBAM8zeYWbDsUE/Y5QY74Ik3MJEq8VFE+v"
+          + "cxw2IYR1yRAKwNkdacZU4RDmXVRh3iJ3Xo+TWScOShXe89MAYuNsuYghwaIZboh6"
+          + "uOYNudrNklQ+CyKlI7jUzK/aXbEHUWkXRBBa6kuJzLLNXLywtlr3Ii135XmdUZqY"
+          + "SNci5HXFKh+ya0h0oFWCBowfFN8CTkuMQdnwF1dQ8I+6DWV/ekd9gtvGeF/7LR72"
+          + "D6xWimZ12mio7ZnPN+qY1oatZMRcNLv2AlrPsabym43nkkxqE7tg45d4L8FYO/lw"
+          + "UHWZYY5VgognbR6QoSYEw5nxhrCPMgRP2HVnosMgqDEeLJoyTR4tEN0CAwEAAaNT"
+          + "MFEwHQYDVR0OBBYEFMs1oSbFkDlkMxJ+Q6vCF+k/QPPoMB8GA1UdIwQYMBaAFMs1"
+          + "oSbFkDlkMxJ+Q6vCF+k/QPPoMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL"
+          + "BQADggEBAK+41x+GT+5QULHTW4Ri606KWt0MrYUPIEcRQEFi1Qi8fepnz6Hbl4P/"
+          + "DirtQEBjgoPrUJGZVxxMaRqz0psJUPKwKQfUEfS/N/sEXTVCb10UIFC++qD3iZNT"
+          + "tUT+jaGHsEX0bT/Zkw7ixszxlqZh546z82M33Xdh4HRBfFLnMjvJAIfdrL9YDeEI"
+          + "EelUN4nrLxMMRZCf8tSK7VvFk9dRpuP00o0PRDzEOPC5utLUsDEkb8bCW0s2c1ZN"
+          + "+b+UrCYOvboDB533DjrGwHIq7Znp08r+u14oB98aa9ghivVKYof/VQRls6CXlRq4"
+          + "Qd7XDenttvOwWlAvxXFencBPfNJrVag=";
+
+    // CRL signed by the CA above, revoking one leaf with serial 0x2000.
+    private static final String CRL_B64 =
+            "MIIBiTBzAgEBMA0GCSqGSIb3DQEBCwUAMBkxFzAVBgNVBAMMDkpvc3RsZSBUZXN0"
+          + "IENBFw0yNjA2MDYwMDEwNDhaFw0zNjA2MDMwMDEwNDhaMBUwEwICIAAXDTI2MDYw"
+          + "NjAwMTA0OFqgDzANMAsGA1UdFAQEAgIQADANBgkqhkiG9w0BAQsFAAOCAQEAeuBm"
+          + "C/c7wjrVsRqOFZiUkEMMMK/Pjwa2MvNNKlly8X39seBfuHDlOXF3k2VgILncf0XC"
+          + "RhGGqP76V+89RK0H4rbcEg5oucsAf+eRQANRgZ7/zJQb1d9Ww6yjoEEEJpXTEUe1"
+          + "WdTIsEoOWnl/VKTjJ+aW/AcL4bw3WkcxpvUC4yDKkiwrhnd0LR+3nE8fBdxLkks7"
+          + "nUODsHAAr5GBFlGvX5YgbfBfwwDhOymv7ykvdjJXOd1KG9r7P3BptOecTWTrogtW"
+          + "e8ys2kwz/qbEIWBnT7QIC129EamJ5RS5JWsWs43VoQy8ELj3on7N/WaWZ501m2KB"
+          + "g7oHwW/9CNPoDpHBDA==";
+
+    /** Serial number of the single revoked entry in {@link #CRL_B64}. */
+    private static final BigInteger REVOKED_SERIAL = BigInteger.valueOf(0x2000);
+
+    private static byte[] rsaCertDer()
+    {
+        return Base64.getDecoder().decode(RSA_CERT_B64);
+    }
+
+    private static byte[] caCertDer()
+    {
+        return Base64.getDecoder().decode(CA_CERT_B64);
+    }
+
+    private static byte[] crlDer()
+    {
+        return Base64.getDecoder().decode(CRL_B64);
+    }
+
+    private static byte[] ecCertDer()
+    {
+        return Base64.getDecoder().decode(EC_CERT_B64);
+    }
+
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    private static X509Certificate parse(byte[] der) throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+        return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(der));
+    }
+
+    // -----------------------------------------------------------------
+    // Provider plumbing
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testFactory_resolvesByNameAndAlias() throws Exception
+    {
+        // Both the canonical "X.509" name and the "X509" alias must resolve
+        // to the JSL factory.
+        CertificateFactory byName = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+        CertificateFactory byAlias = CertificateFactory.getInstance("X509", JostleProvider.PROVIDER_NAME);
+        Assertions.assertEquals(JostleProvider.PROVIDER_NAME, byName.getProvider().getName());
+        Assertions.assertEquals(JostleProvider.PROVIDER_NAME, byAlias.getProvider().getName());
+    }
+
+    // -----------------------------------------------------------------
+    // getPublicKey() returns a working JSL key
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testRsaCert_publicKeyIsJslAndVerifiesSelfSignature() throws Exception
+    {
+        X509Certificate cert = parse(rsaCertDer());
+        assertPublicKeyIsJslAndVerifies(cert);
+    }
+
+    @Test
+    public void testEcCert_publicKeyIsJslAndVerifiesSelfSignature() throws Exception
+    {
+        X509Certificate cert = parse(ecCertDer());
+        assertPublicKeyIsJslAndVerifies(cert);
+    }
+
+    /**
+     * The wrapped certificate's public key must come from the JSL provider,
+     * and it must verify the certificate's own (self-signed) signature when
+     * driven through a JSL {@link Signature}. A tampered TBS must NOT verify
+     * — proving the verify actually consumes the bytes rather than rubber-
+     * stamping (CLAUDE.md negative-path rule).
+     */
+    private static void assertPublicKeyIsJslAndVerifies(X509Certificate cert) throws Exception
+    {
+        PublicKey pub = cert.getPublicKey();
+        Assertions.assertTrue(pub.getClass().getName().startsWith("org.openssl.jostle"),
+                "getPublicKey() did not return a JSL key, was: " + pub.getClass().getName());
+
+        byte[] tbs = cert.getTBSCertificate();
+        byte[] sig = cert.getSignature();
+
+        Signature verifier = Signature.getInstance(cert.getSigAlgName(), JostleProvider.PROVIDER_NAME);
+        verifier.initVerify(pub);
+        verifier.update(tbs);
+        Assertions.assertTrue(verifier.verify(sig),
+                cert.getSigAlgName() + ": JSL key failed to verify the cert's self-signature");
+
+        // Negative: flip a byte in the TBS — verification must fail.
+        byte[] tamperedTbs = tbs.clone();
+        tamperedTbs[tamperedTbs.length / 2] ^= 0x01;
+        Signature verifier2 = Signature.getInstance(cert.getSigAlgName(), JostleProvider.PROVIDER_NAME);
+        verifier2.initVerify(pub);
+        verifier2.update(tamperedTbs);
+        Assertions.assertFalse(verifier2.verify(sig),
+                cert.getSigAlgName() + ": tampered TBS unexpectedly verified");
+    }
+
+    // -----------------------------------------------------------------
+    // Bulk entry points
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testGenerateCertificates_collectionWrapsEachAsJslKeyed() throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+        Collection<? extends Certificate> certs =
+                cf.generateCertificates(new ByteArrayInputStream(rsaCertDer()));
+        Assertions.assertEquals(1, certs.size());
+        for (Certificate c : certs)
+        {
+            // Each wrapped cert must hand back a JSL public key.
+            Assertions.assertTrue(c.getPublicKey().getClass().getName().startsWith("org.openssl.jostle"),
+                    "generateCertificates element returned a non-JSL key");
+        }
+    }
+
+    @Test
+    public void testGenerateCertPath_roundTrips() throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+
+        List<Certificate> list = new ArrayList<Certificate>();
+        list.add(parse(rsaCertDer()));
+        CertPath path = cf.generateCertPath(list);
+        Assertions.assertEquals(1, path.getCertificates().size());
+
+        // Encode then re-parse — the encoded form must round-trip back to an
+        // equal cert list through the same factory.
+        byte[] encoded = path.getEncoded();
+        CertPath reparsed = cf.generateCertPath(new ByteArrayInputStream(encoded));
+        Assertions.assertArrayEquals(
+                list.get(0).getEncoded(),
+                reparsed.getCertificates().get(0).getEncoded(),
+                "CertPath did not round-trip through encode/parse");
+    }
+
+    // -----------------------------------------------------------------
+    // CRL parsing (delegated passthrough)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testGenerateCRL_parsesAndReportsRevokedEntry() throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+        X509CRL crl = (X509CRL) cf.generateCRL(new ByteArrayInputStream(crlDer()));
+
+        Assertions.assertEquals("CN=Jostle Test CA", crl.getIssuerX500Principal().getName());
+
+        // The revoked leaf (serial 0x2000) must be reported as revoked, and an
+        // unrelated serial must not be — proving the CRL body was actually parsed.
+        X509CRLEntry entry = crl.getRevokedCertificate(REVOKED_SERIAL);
+        Assertions.assertNotNull(entry, "expected serial 0x2000 to be revoked");
+        Assertions.assertEquals(REVOKED_SERIAL, entry.getSerialNumber());
+        Assertions.assertNull(crl.getRevokedCertificate(BigInteger.valueOf(0x9999)),
+                "an unrevoked serial was unexpectedly reported as revoked");
+    }
+
+    @Test
+    public void testGenerateCRL_verifiesWithCaKeyParsedThroughJsl() throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+
+        // Parse the CA cert through the JSL factory (its getPublicKey() yields a
+        // JSL key) and use that key to verify the CRL's signature end-to-end.
+        X509Certificate caCert =
+                (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(caCertDer()));
+        PublicKey caKey = caCert.getPublicKey();
+        Assertions.assertTrue(caKey.getClass().getName().startsWith("org.openssl.jostle"),
+                "CA getPublicKey() did not return a JSL key");
+
+        X509CRL crl = (X509CRL) cf.generateCRL(new ByteArrayInputStream(crlDer()));
+        // Must not throw — the JSL key verifies the CRL's signature via the JSL
+        // provider's Signature SPI.
+        crl.verify(caKey, JostleProvider.PROVIDER_NAME);
+    }
+
+    @Test
+    public void testGenerateCRLs_collection() throws Exception
+    {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", JostleProvider.PROVIDER_NAME);
+        Collection<? extends java.security.cert.CRL> crls =
+                cf.generateCRLs(new ByteArrayInputStream(crlDer()));
+        Assertions.assertEquals(1, crls.size());
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/md/ShakeFixedLengthTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/md/ShakeFixedLengthTest.java
@@ -1,0 +1,154 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.md;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.util.Arrays;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.Security;
+
+/**
+ * Tests for the fixed-output SHAKE MessageDigest registrations
+ * {@code SHAKE128-256} and {@code SHAKE256-512} added to {@code ProvMD}.
+ *
+ * <p>These names treat SHAKE as a plain hash squeezed to a fixed length
+ * (256 / 512 bits) — the form BouncyCastle's CMS/PKIX layer asks for. JSL
+ * maps them onto SHAKE-128 / SHAKE-256 with a fixed 32 / 64-byte output, so
+ * the output must byte-match BC's default-length {@code SHAKE128} /
+ * {@code SHAKE256} digests (which produce 32 / 64 bytes).
+ */
+public class ShakeFixedLengthTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static SecureRandom seededRandom(String testName) throws Exception
+    {
+        long seed = RANDOM.nextLong();
+        System.out.println(testName + " seed=" + seed);
+        SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        sr.setSeed(seed);
+        return sr;
+    }
+
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Test
+    public void testDigestLengths() throws Exception
+    {
+        Assertions.assertEquals(32,
+                MessageDigest.getInstance("SHAKE128-256", JostleProvider.PROVIDER_NAME).getDigestLength());
+        Assertions.assertEquals(64,
+                MessageDigest.getInstance("SHAKE256-512", JostleProvider.PROVIDER_NAME).getDigestLength());
+    }
+
+    @Test
+    public void testShake128_256_agreesWithBC() throws Exception
+    {
+        agreesWithBC("testShake128_256_agreesWithBC", "SHAKE128-256", "SHAKE128", 32);
+    }
+
+    @Test
+    public void testShake256_512_agreesWithBC() throws Exception
+    {
+        agreesWithBC("testShake256_512_agreesWithBC", "SHAKE256-512", "SHAKE256", 64);
+    }
+
+    /**
+     * Multi-trial random-input agreement: JSL's fixed-length SHAKE digest must
+     * equal BC's default-length SHAKE digest of the same input. Varies the
+     * input length per trial so a length-dependent finalisation bug surfaces.
+     */
+    private static void agreesWithBC(String testName, String jslName, String bcName, int expectedLen)
+            throws Exception
+    {
+        SecureRandom sr = seededRandom(testName);
+        for (int trial = 0; trial < 25; trial++)
+        {
+            byte[] msg = new byte[sr.nextInt(4096)];
+            sr.nextBytes(msg);
+
+            MessageDigest jsl = MessageDigest.getInstance(jslName, JostleProvider.PROVIDER_NAME);
+            MessageDigest bc = MessageDigest.getInstance(bcName, BouncyCastleProvider.PROVIDER_NAME);
+
+            byte[] jslOut = jsl.digest(msg);
+            byte[] bcOut = bc.digest(msg);
+
+            Assertions.assertEquals(expectedLen, jslOut.length, jslName + ": wrong output length");
+            Assertions.assertArrayEquals(bcOut, jslOut,
+                    jslName + " vs BC " + bcName + ": digest mismatch at trial=" + trial + " len=" + msg.length);
+        }
+    }
+
+    @Test
+    public void testChunkingMatchesOneShot() throws Exception
+    {
+        SecureRandom sr = seededRandom("testChunkingMatchesOneShot");
+        for (String name : new String[]{"SHAKE128-256", "SHAKE256-512"})
+        {
+            byte[] msg = new byte[1024 + sr.nextInt(1024)];
+            sr.nextBytes(msg);
+
+            MessageDigest oneShot = MessageDigest.getInstance(name, JostleProvider.PROVIDER_NAME);
+            byte[] expected = oneShot.digest(msg);
+
+            // Byte-by-byte update must produce the identical digest.
+            MessageDigest incremental = MessageDigest.getInstance(name, JostleProvider.PROVIDER_NAME);
+            for (byte b : msg)
+            {
+                incremental.update(b);
+            }
+            Assertions.assertArrayEquals(expected, incremental.digest(),
+                    name + ": byte-by-byte digest diverged from one-shot");
+        }
+    }
+
+    /**
+     * Negative path: distinct inputs must produce distinct digests, and a
+     * single-bit change must change the output. A stub that ignores input
+     * bytes (or hashes only a prefix) fails here.
+     */
+    @Test
+    public void testDistinctInputsProduceDistinctDigests() throws Exception
+    {
+        SecureRandom sr = seededRandom("testDistinctInputsProduceDistinctDigests");
+        for (String name : new String[]{"SHAKE128-256", "SHAKE256-512"})
+        {
+            byte[] a = new byte[128];
+            sr.nextBytes(a);
+            byte[] b = Arrays.clone(a);
+            b[64] ^= 0x01; // single-bit difference
+
+            byte[] da = MessageDigest.getInstance(name, JostleProvider.PROVIDER_NAME).digest(a);
+            byte[] db = MessageDigest.getInstance(name, JostleProvider.PROVIDER_NAME).digest(b);
+
+            Assertions.assertFalse(Arrays.areEqual(da, db),
+                    name + ": single-bit-different inputs produced identical digests");
+        }
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/provider/ForeignKeyImportTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/provider/ForeignKeyImportTest.java
@@ -1,0 +1,232 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.provider;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+
+/**
+ * Tests that JSL's RSA and ECDSA Signature SPIs accept <em>foreign</em> key
+ * objects directly — i.e. a key instance from another provider passed straight
+ * to {@code initVerify} / {@code initSign} without the caller first re-importing
+ * it through a JSL {@code KeyFactory}.
+ *
+ * <p>This exercises the new {@code importPublic} / {@code importPrivate}
+ * coercion in {@code RSASignatureSpiBase} and {@code ECDSASignatureSpi}, which
+ * re-import foreign keys via {@code engineTranslateKey}. The motivating case is
+ * the CMS/PKIX verifier handing over a {@code sun.*} key parsed from a
+ * certificate (mirrored here with BouncyCastle keys, which are likewise not JSL
+ * key types).
+ *
+ * <p>Unlike the existing {@code *BCAgreement*} tests in {@code RSATest} /
+ * {@code ECDSATest} — which manually round-trip the foreign key through a JSL
+ * {@code KeyFactory} before {@code init} — these pass the raw foreign key
+ * object, so they cover the coercion path itself. Both directions are tested,
+ * and a wrong-algorithm foreign key must still be rejected with
+ * {@link InvalidKeyException}.
+ */
+public class ForeignKeyImportTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    private static byte[] randomMessage(int len)
+    {
+        byte[] m = new byte[len];
+        RANDOM.nextBytes(m);
+        return m;
+    }
+
+    // -----------------------------------------------------------------
+    // RSA (PKCS#1 v1.5)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testRsa_foreignPublicKeyObject_acceptedByJslVerify() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(2048);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+        byte[] msg = randomMessage(200);
+
+        // BC signs.
+        Signature bcSigner = Signature.getInstance("SHA256withRSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcSigner.initSign(bcKp.getPrivate());
+        bcSigner.update(msg);
+        byte[] sig = bcSigner.sign();
+
+        // JSL verifies using the raw BC public key object (no manual re-import).
+        Signature joVerifier = Signature.getInstance("SHA256withRSA", JostleProvider.PROVIDER_NAME);
+        joVerifier.initVerify(bcKp.getPublic());
+        joVerifier.update(msg);
+        Assertions.assertTrue(joVerifier.verify(sig),
+                "JSL verify failed against a raw foreign (BC) RSA public key");
+    }
+
+    @Test
+    public void testRsa_foreignPrivateKeyObject_acceptedByJslSign() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(2048);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+        byte[] msg = randomMessage(200);
+
+        // JSL signs using the raw BC private key object (no manual re-import).
+        Signature joSigner = Signature.getInstance("SHA256withRSA", JostleProvider.PROVIDER_NAME);
+        joSigner.initSign(bcKp.getPrivate());
+        joSigner.update(msg);
+        byte[] sig = joSigner.sign();
+
+        // BC verifies with its own public key.
+        Signature bcVerifier = Signature.getInstance("SHA256withRSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcVerifier.initVerify(bcKp.getPublic());
+        bcVerifier.update(msg);
+        Assertions.assertTrue(bcVerifier.verify(sig),
+                "BC verify failed against a JSL signature made with a raw foreign (BC) RSA private key");
+    }
+
+    @Test
+    public void testRsaPss_foreignKeyObjects_roundTrip() throws Exception
+    {
+        // The coercion lives in the shared RSASignatureSpiBase, so PSS gets it
+        // too. Default PSS params (SHA-256/MGF1-SHA-256) on both ends.
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(2048);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+        byte[] msg = randomMessage(200);
+
+        Signature joSigner = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        joSigner.initSign(bcKp.getPrivate());
+        joSigner.update(msg);
+        byte[] sig = joSigner.sign();
+
+        Signature joVerifier = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        joVerifier.initVerify(bcKp.getPublic());
+        joVerifier.update(msg);
+        Assertions.assertTrue(joVerifier.verify(sig),
+                "JSL PSS round-trip failed using raw foreign (BC) RSA key objects");
+    }
+
+    // -----------------------------------------------------------------
+    // ECDSA
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testEcdsa_foreignPublicKeyObject_acceptedByJslVerify() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair bcKp = bcKpg.generateKeyPair();
+        byte[] msg = randomMessage(200);
+
+        Signature bcSigner = Signature.getInstance("SHA256withECDSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcSigner.initSign(bcKp.getPrivate());
+        bcSigner.update(msg);
+        byte[] sig = bcSigner.sign();
+
+        Signature joVerifier = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        joVerifier.initVerify(bcKp.getPublic());
+        joVerifier.update(msg);
+        Assertions.assertTrue(joVerifier.verify(sig),
+                "JSL verify failed against a raw foreign (BC) EC public key");
+    }
+
+    @Test
+    public void testEcdsa_foreignPrivateKeyObject_acceptedByJslSign() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair bcKp = bcKpg.generateKeyPair();
+        byte[] msg = randomMessage(200);
+
+        Signature joSigner = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        joSigner.initSign(bcKp.getPrivate());
+        joSigner.update(msg);
+        byte[] sig = joSigner.sign();
+
+        Signature bcVerifier = Signature.getInstance("SHA256withECDSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcVerifier.initVerify(bcKp.getPublic());
+        bcVerifier.update(msg);
+        Assertions.assertTrue(bcVerifier.verify(sig),
+                "BC verify failed against a JSL signature made with a raw foreign (BC) EC private key");
+    }
+
+    // -----------------------------------------------------------------
+    // Negative path: wrong-algorithm foreign key still rejected
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testRsaSignature_rejectsForeignEcKey() throws Exception
+    {
+        // A foreign EC key handed to a JSL RSA Signature must still surface
+        // InvalidKeyException (so JCE provider fallback works) — the coercion
+        // must not turn a wrong-algorithm key into a silent success.
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair bcKp = bcKpg.generateKeyPair();
+
+        Signature joVerifier = Signature.getInstance("SHA256withRSA", JostleProvider.PROVIDER_NAME);
+        try
+        {
+            joVerifier.initVerify(bcKp.getPublic());
+            Assertions.fail("expected InvalidKeyException for a foreign EC key on an RSA Signature");
+        }
+        catch (InvalidKeyException expected)
+        {
+            Assertions.assertEquals("expected an RSAPublicKey from the Jostle provider",
+                    expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testEcdsaSignature_rejectsForeignRsaKey() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(2048);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+
+        Signature joVerifier = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        try
+        {
+            joVerifier.initVerify(bcKp.getPublic());
+            Assertions.fail("expected InvalidKeyException for a foreign RSA key on an ECDSA Signature");
+        }
+        catch (InvalidKeyException expected)
+        {
+            Assertions.assertEquals("expected an ECPublicKey from the Jostle provider",
+                    expected.getMessage());
+        }
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/provider/KeyEqualityTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/provider/KeyEqualityTest.java
@@ -1,0 +1,216 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.provider;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.jcajce.spec.ScryptKeySpec;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+/**
+ * Tests the value-equality contracts added to JSL key types:
+ * <ul>
+ *   <li>{@code AsymmetricKeyImpl} (RSA / EC public + private keys) — encoded-form
+ *       equality; encoding embeds the algorithm OID and key role, so two keys
+ *       with the same encoding are equal regardless of provider,</li>
+ *   <li>{@code JOPBEKey} and {@code JOScryptKey} — algorithm (case-insensitive)
+ *       plus raw-key equality, following the {@code SecretKeySpec} contract.</li>
+ * </ul>
+ *
+ * <p>Before these overrides, JSL keys inherited identity equality, so two
+ * instances of the same key never compared equal — breaking callers that key
+ * collections on keys or compare a parsed key against a certificate's key. Each
+ * case asserts both directions of the contract: equal-when-same and (the
+ * negative path) unequal-when-different, plus {@code equals}/{@code hashCode}
+ * consistency.
+ */
+public class KeyEqualityTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // AsymmetricKeyImpl — RSA
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testRsaPublicKey_encodedEqualityAndHashCode() throws Exception
+    {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        KeyFactory kf = KeyFactory.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        PublicKey reimported = kf.generatePublic(new X509EncodedKeySpec(kp.getPublic().getEncoded()));
+
+        // Two distinct JSL instances of the same key must be equal with equal hashCodes.
+        Assertions.assertNotSame(kp.getPublic(), reimported);
+        Assertions.assertEquals(kp.getPublic(), reimported);
+        Assertions.assertEquals(reimported, kp.getPublic());
+        Assertions.assertEquals(kp.getPublic().hashCode(), reimported.hashCode());
+
+        // A different key must not be equal.
+        KeyPair other = kpg.generateKeyPair();
+        Assertions.assertNotEquals(kp.getPublic(), other.getPublic());
+
+        // Public must not equal the private half of the same pair (different encoding/role).
+        Assertions.assertNotEquals((Object) kp.getPublic(), (Object) kp.getPrivate());
+    }
+
+    @Test
+    public void testRsaPrivateKey_encodedEqualityAndHashCode() throws Exception
+    {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        KeyFactory kf = KeyFactory.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        PrivateKey reimported = kf.generatePrivate(new PKCS8EncodedKeySpec(kp.getPrivate().getEncoded()));
+
+        Assertions.assertNotSame(kp.getPrivate(), reimported);
+        Assertions.assertEquals(kp.getPrivate(), reimported);
+        Assertions.assertEquals(kp.getPrivate().hashCode(), reimported.hashCode());
+
+        KeyPair other = kpg.generateKeyPair();
+        Assertions.assertNotEquals(kp.getPrivate(), other.getPrivate());
+    }
+
+    @Test
+    public void testRsaPublicKey_equalsForeignKeyWithSameEncoding() throws Exception
+    {
+        // Encoded-form equality is provider-agnostic: a BC RSA public key with
+        // byte-identical SubjectPublicKeyInfo must compare equal to the JSL key.
+        // This is the "compare a parsed key against a certificate's key" use case.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        KeyFactory bcKf = KeyFactory.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        PublicKey bcPub = bcKf.generatePublic(new X509EncodedKeySpec(kp.getPublic().getEncoded()));
+
+        Assertions.assertArrayEquals(kp.getPublic().getEncoded(), bcPub.getEncoded(),
+                "precondition: BC re-encode must be byte-identical");
+        Assertions.assertEquals(kp.getPublic(), bcPub,
+                "JSL key did not equal a foreign key with identical encoding");
+    }
+
+    // -----------------------------------------------------------------
+    // AsymmetricKeyImpl — EC
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testEcKeys_encodedEqualityAndHashCode() throws Exception
+    {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        KeyFactory kf = KeyFactory.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        PublicKey reimportedPub = kf.generatePublic(new X509EncodedKeySpec(kp.getPublic().getEncoded()));
+        PrivateKey reimportedPriv = kf.generatePrivate(new PKCS8EncodedKeySpec(kp.getPrivate().getEncoded()));
+
+        Assertions.assertEquals(kp.getPublic(), reimportedPub);
+        Assertions.assertEquals(kp.getPublic().hashCode(), reimportedPub.hashCode());
+        Assertions.assertEquals(kp.getPrivate(), reimportedPriv);
+        Assertions.assertEquals(kp.getPrivate().hashCode(), reimportedPriv.hashCode());
+
+        KeyPair other = kpg.generateKeyPair();
+        Assertions.assertNotEquals(kp.getPublic(), other.getPublic());
+        Assertions.assertNotEquals(kp.getPrivate(), other.getPrivate());
+    }
+
+    // -----------------------------------------------------------------
+    // JOPBEKey
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testPbeKey_algorithmAndRawKeyEquality() throws Exception
+    {
+        byte[] salt = new byte[16];
+        RANDOM.nextBytes(salt);
+        char[] pwd = "correct horse battery staple".toCharArray();
+
+        SecretKeyFactory kf = SecretKeyFactory.getInstance("PBKDF2WITHHMACSHA256", JostleProvider.PROVIDER_NAME);
+        SecretKey k1 = kf.generateSecret(new PBEKeySpec(pwd, salt, 1000, 256));
+        SecretKey k2 = kf.generateSecret(new PBEKeySpec(pwd, salt, 1000, 256));
+
+        // Same derivation → equal with equal hashCodes.
+        Assertions.assertNotSame(k1, k2);
+        Assertions.assertEquals(k1, k2);
+        Assertions.assertEquals(k1.hashCode(), k2.hashCode());
+
+        // A SecretKeySpec carrying the same algorithm + bytes is equal (the
+        // override accepts any SecretKey, per the SecretKeySpec contract).
+        SecretKey spec = new SecretKeySpec(k1.getEncoded(), k1.getAlgorithm());
+        Assertions.assertEquals(k1, spec);
+
+        // Different password → different key.
+        SecretKey k3 = kf.generateSecret(new PBEKeySpec("different".toCharArray(), salt, 1000, 256));
+        Assertions.assertNotEquals(k1, k3);
+    }
+
+    // -----------------------------------------------------------------
+    // JOScryptKey
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testScryptKey_algorithmAndRawKeyEquality() throws Exception
+    {
+        byte[] salt = new byte[16];
+        RANDOM.nextBytes(salt);
+        char[] pwd = "scrypt password".toCharArray();
+
+        SecretKeyFactory kf = SecretKeyFactory.getInstance("SCRYPT", JostleProvider.PROVIDER_NAME);
+        SecretKey k1 = kf.generateSecret(new ScryptKeySpec(pwd, salt, 2, 1, 1, 256));
+        SecretKey k2 = kf.generateSecret(new ScryptKeySpec(pwd, salt, 2, 1, 1, 256));
+
+        Assertions.assertNotSame(k1, k2);
+        Assertions.assertEquals(k1, k2);
+        Assertions.assertEquals(k1.hashCode(), k2.hashCode());
+
+        SecretKey spec = new SecretKeySpec(k1.getEncoded(), k1.getAlgorithm());
+        Assertions.assertEquals(k1, spec);
+
+        // Different password → different key.
+        SecretKey k3 = kf.generateSecret(new ScryptKeySpec("other".toCharArray(), salt, 2, 1, 1, 256));
+        Assertions.assertNotEquals(k1, k3);
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSAPSSNamedSignatureTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSAPSSNamedSignatureTest.java
@@ -1,0 +1,214 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.rsa;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+
+/**
+ * Tests for the per-digest RSASSA-PSS convenience Signature names registered by
+ * {@code ProvRSA} — {@code <digest>WITHRSAANDMGF1} and the
+ * {@code <digest>WITHRSASSA-PSS} aliases — backed by the new
+ * {@code RSAPSSSignatureSpi(String digest)} constructor.
+ *
+ * <p>Each name must carry its own digest default (with MGF1 over the same hash
+ * and salt = digest length), because BC's PKIX/CMS layer drives these names
+ * <em>without</em> calling {@code setParameter} for default parameters. The
+ * java-spi guide flags name-based digest defaults as exactly where a
+ * registration bug silently collapses to the wrong digest, so these tests:
+ * <ol>
+ *   <li>cross-check each name's implicit default against an explicit
+ *       {@link PSSParameterSpec} verified by BouncyCastle (both directions),</li>
+ *   <li>confirm the {@code WITHRSASSA-PSS} alias resolves and round-trips,</li>
+ *   <li>prove an explicit {@code setParameter} overrides the name's default,</li>
+ *   <li>exercise the negative path (tampered message must not verify).</li>
+ * </ol>
+ */
+public class RSAPSSNamedSignatureTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static KeyPair sharedKeyPair;
+
+    /** {jslAlgName, jcaDigestName, saltLen (= digest output length)}. */
+    private static final String[][] CASES = {
+            {"SHA1WITHRSAANDMGF1", "SHA-1", "20"},
+            {"SHA224WITHRSAANDMGF1", "SHA-224", "28"},
+            {"SHA256WITHRSAANDMGF1", "SHA-256", "32"},
+            {"SHA384WITHRSAANDMGF1", "SHA-384", "48"},
+            {"SHA512WITHRSAANDMGF1", "SHA-512", "64"},
+            {"SHA3-224WITHRSAANDMGF1", "SHA3-224", "28"},
+            {"SHA3-256WITHRSAANDMGF1", "SHA3-256", "32"},
+            {"SHA3-384WITHRSAANDMGF1", "SHA3-384", "48"},
+            {"SHA3-512WITHRSAANDMGF1", "SHA3-512", "64"},
+    };
+
+    @BeforeAll
+    static void before() throws Exception
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        sharedKeyPair = kpg.generateKeyPair();
+    }
+
+    private static byte[] randomMessage(int len)
+    {
+        byte[] m = new byte[len];
+        RANDOM.nextBytes(m);
+        return m;
+    }
+
+    private static PSSParameterSpec pssSpec(String jcaDigest, int saltLen)
+    {
+        return new PSSParameterSpec(jcaDigest, "MGF1", new MGF1ParameterSpec(jcaDigest), saltLen, 1);
+    }
+
+    /**
+     * For each named algorithm: the implicit per-name default must equal an
+     * explicit {@link PSSParameterSpec} of the same digest. Verified both ways
+     * against BouncyCastle, which proves the registration wired the correct
+     * digest / MGF1 / salt (a name collapsing to the wrong digest would fail
+     * BC's explicit-param verify).
+     */
+    @Test
+    public void testNamedDefault_matchesExplicitParams_bothDirections() throws Exception
+    {
+        for (String[] c : CASES)
+        {
+            String jslName = c[0];
+            String jcaDigest = c[1];
+            int saltLen = Integer.parseInt(c[2]);
+            PSSParameterSpec spec = pssSpec(jcaDigest, saltLen);
+            byte[] msg = randomMessage(200);
+
+            // Sign with JSL named (no setParameter), verify with BC explicit params.
+            Signature joSigner = Signature.getInstance(jslName, JostleProvider.PROVIDER_NAME);
+            joSigner.initSign(sharedKeyPair.getPrivate());
+            joSigner.update(msg);
+            byte[] joSig = joSigner.sign();
+
+            Signature bcVerifier = Signature.getInstance("RSASSA-PSS", BouncyCastleProvider.PROVIDER_NAME);
+            bcVerifier.setParameter(spec);
+            bcVerifier.initVerify(sharedKeyPair.getPublic());
+            bcVerifier.update(msg);
+            Assertions.assertTrue(bcVerifier.verify(joSig),
+                    jslName + ": JSL-signed sig failed BC verify with explicit " + jcaDigest + " params");
+
+            // Sign with BC explicit params, verify with JSL named (no setParameter).
+            Signature bcSigner = Signature.getInstance("RSASSA-PSS", BouncyCastleProvider.PROVIDER_NAME);
+            bcSigner.setParameter(spec);
+            bcSigner.initSign(sharedKeyPair.getPrivate());
+            bcSigner.update(msg);
+            byte[] bcSig = bcSigner.sign();
+
+            Signature joVerifier = Signature.getInstance(jslName, JostleProvider.PROVIDER_NAME);
+            joVerifier.initVerify(sharedKeyPair.getPublic());
+            joVerifier.update(msg);
+            Assertions.assertTrue(joVerifier.verify(bcSig),
+                    jslName + ": BC-signed sig (explicit " + jcaDigest + ") failed JSL named verify");
+        }
+    }
+
+    @Test
+    public void testWithRSASSAPSSAlias_resolvesAndRoundTrips() throws Exception
+    {
+        for (String[] c : CASES)
+        {
+            // ProvRSA registers the alias as digestName + "WITHRSASSA-PSS", where
+            // digestName is the leading token of the WITHRSAANDMGF1 name
+            // (e.g. "SHA256", "SHA3-256").
+            String digestName = c[0].substring(0, c[0].indexOf("WITHRSAANDMGF1"));
+            String aliasName = digestName + "WITHRSASSA-PSS";
+
+            byte[] msg = randomMessage(128);
+            Signature signer = Signature.getInstance(aliasName, JostleProvider.PROVIDER_NAME);
+            signer.initSign(sharedKeyPair.getPrivate());
+            signer.update(msg);
+            byte[] sig = signer.sign();
+
+            Signature verifier = Signature.getInstance(aliasName, JostleProvider.PROVIDER_NAME);
+            verifier.initVerify(sharedKeyPair.getPublic());
+            verifier.update(msg);
+            Assertions.assertTrue(verifier.verify(sig), aliasName + ": alias round-trip failed");
+        }
+    }
+
+    /**
+     * An explicit {@code setParameter} must override the name's implicit digest
+     * default. Sign with the SHA-256 name but SHA-384 params; the SHA-384
+     * explicit verify succeeds while the SHA-256 default-name verify must fail
+     * — proving the override took effect (and the name default is not frozen).
+     */
+    @Test
+    public void testSetParameter_overridesNameDefault() throws Exception
+    {
+        byte[] msg = randomMessage(200);
+        PSSParameterSpec sha384 = pssSpec("SHA-384", 48);
+
+        Signature signer = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        signer.setParameter(sha384);
+        signer.initSign(sharedKeyPair.getPrivate());
+        signer.update(msg);
+        byte[] sig = signer.sign();
+
+        // SHA-384 explicit verify succeeds.
+        Signature okVerifier = Signature.getInstance("RSASSA-PSS", JostleProvider.PROVIDER_NAME);
+        okVerifier.setParameter(sha384);
+        okVerifier.initVerify(sharedKeyPair.getPublic());
+        okVerifier.update(msg);
+        Assertions.assertTrue(okVerifier.verify(sig), "SHA-384 override sig failed explicit SHA-384 verify");
+
+        // SHA-256 default (name default, no setParameter) must NOT verify a
+        // SHA-384 signature.
+        Signature wrongVerifier = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        wrongVerifier.initVerify(sharedKeyPair.getPublic());
+        wrongVerifier.update(msg);
+        Assertions.assertFalse(wrongVerifier.verify(sig),
+                "SHA-256 default unexpectedly verified a SHA-384 signature");
+    }
+
+    @Test
+    public void testTamperedMessage_doesNotVerify() throws Exception
+    {
+        byte[] msg = randomMessage(200);
+        Signature signer = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        signer.initSign(sharedKeyPair.getPrivate());
+        signer.update(msg);
+        byte[] sig = signer.sign();
+
+        byte[] tampered = msg.clone();
+        tampered[0] ^= 0x01;
+
+        Signature verifier = Signature.getInstance("SHA256WITHRSAANDMGF1", JostleProvider.PROVIDER_NAME);
+        verifier.initVerify(sharedKeyPair.getPublic());
+        verifier.update(tampered);
+        Assertions.assertFalse(verifier.verify(sig), "tampered message unexpectedly verified");
+    }
+}


### PR DESCRIPTION
added X.509 certificate support, foreign key import, key equality/hashCode, missing aliases for ECDSA/SHAKE, tests for changes