### PR TITLE
added OID factory lookup for PQC algorithms, updated cert factory to …

### DIFF
--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMLDSA.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMLDSA.java
@@ -53,6 +53,14 @@ class ProvMLDSA
         provider.addAlgorithmImplementation("Signature", "ML-DSA-EXTERNAL-MU", PREFIX + "MLDSASignatureSpi$MLDSAExternalMu", mldsaSigAttr, (arg) -> new MLDSASignatureSpi(OSSLKeyType.NONE, MLDSASignatureSpi.MuHandling.EXTERNAL_MU));
         provider.addAlgorithmImplementation("Signature", "ML-DSA-CALCULATE-MU", PREFIX + "MLDSASignatureSpi$MLDSACalculateMu", mldsaSigAttr, (arg) -> new MLDSASignatureSpi(OSSLKeyType.NONE, MLDSASignatureSpi.MuHandling.CALCULATE_MU));
 
+        // SPKI / signature-algorithm OID aliases (NIST CSOR id-ml-dsa-44/65/87).
+        // Required so X.509 certs whose SubjectPublicKeyInfo / signature carries
+        // the OID resolve to the JSL Signature, rather than falling back to the
+        // JDK default.
+        provider.addAlias("Signature", "ML-DSA-44", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.17"));
+        provider.addAlias("Signature", "ML-DSA-65", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.18"));
+        provider.addAlias("Signature", "ML-DSA-87", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.19"));
+
 
         final Map<String, String> mldsaKfAttr = new HashMap<>();
         provider.addAlgorithmImplementation("KeyFactory", "MLDSA", PREFIX + "MLDSAKeyFactorySpi", mldsaKfAttr, (arg) -> new MLDSAKeyFactorySpiImpl());
@@ -60,6 +68,13 @@ class ProvMLDSA
         provider.addAlgorithmImplementation("KeyFactory", "ML-DSA-44", PREFIX + "MLDSAKeyFactorySpi$MLDSA44", mldsaKfAttr, (arg) -> new MLDSAKeyFactorySpiImpl(OSSLKeyType.ML_DSA_44));
         provider.addAlgorithmImplementation("KeyFactory", "ML-DSA-65", PREFIX + "MLDSAKeyFactorySpi$MLDSA65", mldsaKfAttr, (arg) -> new MLDSAKeyFactorySpiImpl(OSSLKeyType.ML_DSA_65));
         provider.addAlgorithmImplementation("KeyFactory", "ML-DSA-87", PREFIX + "MLDSAKeyFactorySpi$MLDSA87", mldsaKfAttr, (arg) -> new MLDSAKeyFactorySpiImpl(OSSLKeyType.ML_DSA_87));
+
+        // SPKI OID aliases (NIST CSOR id-ml-dsa-44/65/87) so a certificate's
+        // public key can be re-derived through the JSL KeyFactory keyed on the
+        // SubjectPublicKeyInfo algorithm OID (see JSLKeyX509Certificate).
+        provider.addAlias("KeyFactory", "ML-DSA-44", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.17"));
+        provider.addAlias("KeyFactory", "ML-DSA-65", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.18"));
+        provider.addAlias("KeyFactory", "ML-DSA-87", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.3.19"));
 
 
     }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMLKEM.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvMLKEM.java
@@ -59,6 +59,14 @@ class ProvMLKEM
         provider.addAlgorithmImplementation("KeyFactory", "ML-KEM-768", PREFIX + "MLKEMKeyFactorySpi$MLKEM768", MLKEMKfAttr, (arg) -> new MLKEMKeyFactorySpi(OSSLKeyType.ML_KEM_768));
         provider.addAlgorithmImplementation("KeyFactory", "ML-KEM-1024", PREFIX + "MLKEMKeyFactorySpi$MLKEM1024", MLKEMKfAttr, (arg) -> new MLKEMKeyFactorySpi(OSSLKeyType.ML_KEM_1024));
 
+        // SPKI OID aliases (NIST CSOR id-alg-ml-kem-*, RFC 9814; note the .4.4
+        // "kems" arc, not the .4.3 "sigAlgs" arc) so a certificate's public key
+        // can be re-derived through the JSL KeyFactory keyed on the
+        // SubjectPublicKeyInfo algorithm OID (see JSLKeyX509Certificate).
+        provider.addAlias("KeyFactory", "ML-KEM-512", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.4.1"));
+        provider.addAlias("KeyFactory", "ML-KEM-768", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.4.2"));
+        provider.addAlias("KeyFactory", "ML-KEM-1024", new ASN1ObjectIdentifier("2.16.840.1.101.3.4.4.3"));
+
     }
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvSLHDSA.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvSLHDSA.java
@@ -81,5 +81,32 @@ class ProvSLHDSA
             provider.addAlgorithmImplementation("Signature", algName, PREFIX + "SLHDSASignatureSpi$" + algName.replace("-", "_"), slhdsaSigAttr, (arg) -> new SLHDSASignatureSpi(SLHDSAParameterSpec.fromName(algName).getKeyType()));
         }
 
+        // SPKI / signature-algorithm OID aliases (NIST CSOR id-slh-dsa-*, RFC 9814),
+        // aligned 1:1 with algNames above. Required so an X.509 certificate whose
+        // SubjectPublicKeyInfo / signature carries the OID resolves to the JSL
+        // KeyFactory and Signature (see JSLKeyX509Certificate), rather than falling
+        // back to the JDK default.
+        String[] oids = new String[]
+                {
+                        "2.16.840.1.101.3.4.3.20",  // SLH-DSA-SHA2-128S
+                        "2.16.840.1.101.3.4.3.21",  // SLH-DSA-SHA2-128F
+                        "2.16.840.1.101.3.4.3.22",  // SLH-DSA-SHA2-192S
+                        "2.16.840.1.101.3.4.3.23",  // SLH-DSA-SHA2-192F
+                        "2.16.840.1.101.3.4.3.24",  // SLH-DSA-SHA2-256S
+                        "2.16.840.1.101.3.4.3.25",  // SLH-DSA-SHA2-256F
+                        "2.16.840.1.101.3.4.3.26",  // SLH-DSA-SHAKE-128S
+                        "2.16.840.1.101.3.4.3.27",  // SLH-DSA-SHAKE-128F
+                        "2.16.840.1.101.3.4.3.28",  // SLH-DSA-SHAKE-192S
+                        "2.16.840.1.101.3.4.3.29",  // SLH-DSA-SHAKE-192F
+                        "2.16.840.1.101.3.4.3.30",  // SLH-DSA-SHAKE-256S
+                        "2.16.840.1.101.3.4.3.31"   // SLH-DSA-SHAKE-256F
+                };
+
+        for (int i = 0; i < algNames.length; i++)
+        {
+            provider.addAlias("KeyFactory", algNames[i], new ASN1ObjectIdentifier(oids[i]));
+            provider.addAlias("Signature", algNames[i], new ASN1ObjectIdentifier(oids[i]));
+        }
+
     }
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/JSLKeyX509Certificate.java
@@ -51,17 +51,163 @@ class JSLKeyX509Certificate
     public PublicKey getPublicKey()
     {
         PublicKey key = delegate.getPublicKey();
+        byte[] encoded = key.getEncoded();
+        if (encoded == null)
+        {
+            return key;
+        }
+
+        // Prefer the algorithm OID carried in the SubjectPublicKeyInfo over the
+        // JDK key's getAlgorithm() string. The OID is the canonical algorithm
+        // identifier, and the JSL provider registers its KeyFactories under the
+        // SPKI OID aliases (e.g. 1.2.840.113549.1.1.1 for RSA, 1.2.840.10045.2.1
+        // for EC), whereas getAlgorithm() returns a provider-specific name that
+        // may not match any registered KeyFactory.
+        PublicKey jslKey = importKey(subjectPublicKeyInfoAlgorithmOid(encoded), encoded);
+        if (jslKey == null)
+        {
+            // No KeyFactory registered under the OID (e.g. an algorithm JSL only
+            // registers by name) — fall back to the JDK key's algorithm name.
+            jslKey = importKey(key.getAlgorithm(), encoded);
+        }
+        // The JSL provider has no KeyFactory for this algorithm (or can't import
+        // it); fall back to the JDK-provided key.
+        return jslKey != null ? jslKey : key;
+    }
+
+    /**
+     * Re-derive a JSL public key from its X.509 encoding via the JSL provider's
+     * KeyFactory for {@code algorithm}, or {@code null} if the algorithm is
+     * {@code null}, has no JSL KeyFactory, or the encoding can't be imported.
+     */
+    private PublicKey importKey(String algorithm, byte[] encoded)
+    {
+        if (algorithm == null)
+        {
+            return null;
+        }
         try
         {
-            KeyFactory kf = KeyFactory.getInstance(key.getAlgorithm(), providerName);
-            return kf.generatePublic(new X509EncodedKeySpec(key.getEncoded()));
+            KeyFactory kf = KeyFactory.getInstance(algorithm, providerName);
+            return kf.generatePublic(new X509EncodedKeySpec(encoded));
         }
         catch (NoSuchAlgorithmException | NoSuchProviderException | java.security.spec.InvalidKeySpecException e)
         {
-            // The JSL provider has no KeyFactory for this algorithm (or can't import
-            // it); fall back to the JDK-provided key.
-            return key;
+            return null;
         }
+    }
+
+    /**
+     * Extract the algorithm OID from an X.509 SubjectPublicKeyInfo encoding.
+     *
+     * <pre>
+     * SubjectPublicKeyInfo ::= SEQUENCE {
+     *     algorithm        AlgorithmIdentifier,
+     *     subjectPublicKey BIT STRING }
+     * AlgorithmIdentifier ::= SEQUENCE {
+     *     algorithm        OBJECT IDENTIFIER,
+     *     parameters       ANY DEFINED BY algorithm OPTIONAL }
+     * </pre>
+     *
+     * @return the dotted-decimal OID string, or {@code null} if the bytes can't
+     * be parsed as a SubjectPublicKeyInfo (the caller then falls back to the JDK
+     * key's algorithm name).
+     */
+    private static String subjectPublicKeyInfoAlgorithmOid(byte[] spki)
+    {
+        try
+        {
+            int[] pos = {0};
+            readTag(spki, pos, 0x30);   // SubjectPublicKeyInfo SEQUENCE
+            readLength(spki, pos);
+            readTag(spki, pos, 0x30);   // AlgorithmIdentifier SEQUENCE
+            readLength(spki, pos);
+            readTag(spki, pos, 0x06);   // algorithm OBJECT IDENTIFIER
+            int oidLen = readLength(spki, pos);
+            return decodeObjectIdentifier(spki, pos[0], oidLen);
+        }
+        catch (RuntimeException e)
+        {
+            return null;
+        }
+    }
+
+    private static void readTag(byte[] data, int[] pos, int expected)
+    {
+        if (pos[0] >= data.length || (data[pos[0]] & 0xFF) != expected)
+        {
+            throw new IllegalArgumentException("unexpected ASN.1 tag");
+        }
+        pos[0]++;
+    }
+
+    private static int readLength(byte[] data, int[] pos)
+    {
+        if (pos[0] >= data.length)
+        {
+            throw new IllegalArgumentException("truncated ASN.1 length");
+        }
+        int b = data[pos[0]++] & 0xFF;
+        if ((b & 0x80) == 0)
+        {
+            return b;
+        }
+        int count = b & 0x7F;
+        if (count == 0 || count > 4)
+        {
+            throw new IllegalArgumentException("unsupported ASN.1 length");
+        }
+        int len = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (pos[0] >= data.length)
+            {
+                throw new IllegalArgumentException("truncated ASN.1 length");
+            }
+            len = (len << 8) | (data[pos[0]++] & 0xFF);
+        }
+        if (len < 0)
+        {
+            throw new IllegalArgumentException("ASN.1 length out of range");
+        }
+        return len;
+    }
+
+    private static String decodeObjectIdentifier(byte[] data, int off, int len)
+    {
+        if (len <= 0 || off < 0 || off + len > data.length)
+        {
+            throw new IllegalArgumentException("invalid OID encoding");
+        }
+        StringBuilder sb = new StringBuilder();
+        long value = 0;
+        boolean first = true;
+        for (int i = 0; i < len; i++)
+        {
+            int b = data[off + i] & 0xFF;
+            value = (value << 7) | (b & 0x7F);
+            if ((b & 0x80) == 0)
+            {
+                if (first)
+                {
+                    long firstArc = value / 40 > 2 ? 2 : value / 40;
+                    sb.append(firstArc).append('.').append(value - firstArc * 40);
+                    first = false;
+                }
+                else
+                {
+                    sb.append('.').append(value);
+                }
+                value = 0;
+            }
+        }
+        if (!first && value == 0)
+        {
+            return sb.toString();
+        }
+        // A trailing sub-identifier whose high bit was still set means the OID
+        // was truncated.
+        throw new IllegalArgumentException("truncated OID encoding");
     }
 
     // --- everything else delegates ---

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSAKeyFactorySpiImpl.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSAKeyFactorySpiImpl.java
@@ -15,6 +15,7 @@ import org.openssl.jostle.jcajce.interfaces.MLDSAPublicKey;
 import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.*;
 import org.openssl.jostle.util.asn1.ASNEncoder;
+import org.openssl.jostle.util.asn1.KeyInfoCanonicalizer;
 
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
@@ -55,7 +56,7 @@ public class MLDSAKeyFactorySpiImpl extends KeyFactorySpi
     {
         if (keySpec instanceof X509EncodedKeySpec)
         {
-            byte[] encoded = ((X509EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.subjectPublicKeyInfo(((X509EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromSubjectPublicKeyInfo(encoded, 0, encoded.length);
 
@@ -106,7 +107,7 @@ public class MLDSAKeyFactorySpiImpl extends KeyFactorySpi
         if (keySpec instanceof PKCS8EncodedKeySpec)
         {
 
-            byte[] encoded = ((PKCS8EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.privateKeyInfo(((PKCS8EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyFactorySpi.java
@@ -17,6 +17,7 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.*;
 import org.openssl.jostle.rand.DefaultRandSource;
 import org.openssl.jostle.util.asn1.ASNEncoder;
+import org.openssl.jostle.util.asn1.KeyInfoCanonicalizer;
 
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
@@ -57,7 +58,7 @@ public class MLKEMKeyFactorySpi extends KeyFactorySpi
     {
         if (keySpec instanceof X509EncodedKeySpec)
         {
-            byte[] encoded = ((X509EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.subjectPublicKeyInfo(((X509EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromSubjectPublicKeyInfo(encoded, 0, encoded.length);
 
@@ -109,7 +110,7 @@ public class MLKEMKeyFactorySpi extends KeyFactorySpi
         if (keySpec instanceof PKCS8EncodedKeySpec)
         {
 
-            byte[] encoded = ((PKCS8EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.privateKeyInfo(((PKCS8EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSAKeyFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSAKeyFactorySpi.java
@@ -15,6 +15,7 @@ import org.openssl.jostle.jcajce.interfaces.SLHDSAPublicKey;
 import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.*;
 import org.openssl.jostle.util.asn1.ASNEncoder;
+import org.openssl.jostle.util.asn1.KeyInfoCanonicalizer;
 
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
@@ -63,7 +64,7 @@ public class SLHDSAKeyFactorySpi extends KeyFactorySpi
     {
         if (keySpec instanceof X509EncodedKeySpec)
         {
-            byte[] encoded = ((X509EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.subjectPublicKeyInfo(((X509EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromSubjectPublicKeyInfo(encoded, 0, encoded.length);
 
@@ -109,7 +110,7 @@ public class SLHDSAKeyFactorySpi extends KeyFactorySpi
         if (keySpec instanceof PKCS8EncodedKeySpec)
         {
 
-            byte[] encoded = ((PKCS8EncodedKeySpec) keySpec).getEncoded();
+            byte[] encoded = KeyInfoCanonicalizer.privateKeyInfo(((PKCS8EncodedKeySpec) keySpec).getEncoded());
 
             PKEYKeySpec pkeySpec = ASNEncoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
 

--- a/jostle/src/main/java/org/openssl/jostle/util/asn1/KeyInfoCanonicalizer.java
+++ b/jostle/src/main/java/org/openssl/jostle/util/asn1/KeyInfoCanonicalizer.java
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.util.asn1;
+
+import org.openssl.jostle.util.Arrays;
+
+/**
+ * Canonicalises the {@code AlgorithmIdentifier} carried in a
+ * SubjectPublicKeyInfo or PrivateKeyInfo so it is acceptable to OpenSSL.
+ * <p>
+ * FIPS 203 (ML-KEM), FIPS 204 (ML-DSA) and FIPS 205 (SLH-DSA), together with
+ * the LAMPS certificate/key profiles, require the {@code parameters} field of
+ * the AlgorithmIdentifier to be <em>absent</em>. Some providers instead encode
+ * the absent parameters as an explicit ASN.1 NULL — notably the JDK's
+ * {@code sun.security.x509.X509Key}, which re-encodes a key for an algorithm it
+ * does not itself recognise and emits {@code 05 00}. OpenSSL's decoders reject
+ * such an encoding (it surfaces as an {@code X509_PUBKEY_get0} / key-decode
+ * error), so these helpers rebuild the structure with the stray NULL removed
+ * before the bytes reach OpenSSL.
+ * <p>
+ * Only an exact NULL parameters element is stripped. Any input that does not
+ * match the expected shape (or carries non-NULL parameters) is returned
+ * unchanged, leaving OpenSSL to report the original error.
+ */
+public final class KeyInfoCanonicalizer
+{
+    private KeyInfoCanonicalizer()
+    {
+    }
+
+    /**
+     * Strip a stray NULL {@code parameters} from the AlgorithmIdentifier of a
+     * {@code SubjectPublicKeyInfo ::= SEQUENCE { AlgorithmIdentifier, BIT STRING }}.
+     */
+    public static byte[] subjectPublicKeyInfo(byte[] spki)
+    {
+        try
+        {
+            int[] pos = {0};
+            int end = readSequenceHeader(spki, pos);        // SubjectPublicKeyInfo
+            int[] algPos = {pos[0]};
+            int algEnd = readSequenceHeader(spki, algPos);  // AlgorithmIdentifier
+
+            byte[] algId = strippedAlgorithmIdentifier(spki, algPos[0], algEnd);
+            if (algId == null)
+            {
+                return spki;
+            }
+
+            byte[] subjectPublicKey = Arrays.copyOfRange(spki, algEnd, end);
+            return derSequence(Arrays.concatenate(algId, subjectPublicKey));
+        }
+        catch (RuntimeException e)
+        {
+            return spki;
+        }
+    }
+
+    /**
+     * Strip a stray NULL {@code parameters} from the privateKeyAlgorithm of a
+     * {@code PrivateKeyInfo ::= SEQUENCE { INTEGER version, AlgorithmIdentifier,
+     * OCTET STRING privateKey, ... }}. Any trailing fields (attributes [0],
+     * publicKey [1]) are preserved verbatim.
+     */
+    public static byte[] privateKeyInfo(byte[] pki)
+    {
+        try
+        {
+            int[] pos = {0};
+            int end = readSequenceHeader(pki, pos);         // PrivateKeyInfo
+            int versionStart = pos[0];
+            int[] versionPos = {versionStart};
+            skipTlv(pki, versionPos);                       // version INTEGER
+            int algStart = versionPos[0];
+            int[] algPos = {algStart};
+            int algEnd = readSequenceHeader(pki, algPos);   // privateKeyAlgorithm
+
+            byte[] algId = strippedAlgorithmIdentifier(pki, algPos[0], algEnd);
+            if (algId == null)
+            {
+                return pki;
+            }
+
+            byte[] version = Arrays.copyOfRange(pki, versionStart, algStart);
+            byte[] rest = Arrays.copyOfRange(pki, algEnd, end);  // OCTET STRING + optional fields
+            return derSequence(Arrays.concatenate(version, algId, rest));
+        }
+        catch (RuntimeException e)
+        {
+            return pki;
+        }
+    }
+
+    /**
+     * If the AlgorithmIdentifier whose content spans {@code [algContentStart, algEnd)}
+     * carries exactly an OBJECT IDENTIFIER followed by a NULL, return a rebuilt
+     * AlgorithmIdentifier TLV ({@code SEQUENCE { OID }}) with the NULL removed;
+     * otherwise return {@code null} to signal "nothing to canonicalise".
+     */
+    private static byte[] strippedAlgorithmIdentifier(byte[] data, int algContentStart, int algEnd)
+    {
+        int[] pos = {algContentStart};
+        int oidStart = pos[0];
+        skipTlv(data, pos);                                 // algorithm OBJECT IDENTIFIER
+        int oidEnd = pos[0];
+
+        if (pos[0] >= algEnd)
+        {
+            return null;                                    // no parameters -> already conformant
+        }
+        // Only an exact NULL (05 00) filling the remainder of the AlgorithmIdentifier is stripped.
+        if (algEnd - pos[0] != 2
+                || (data[pos[0]] & 0xFF) != 0x05
+                || (data[pos[0] + 1] & 0xFF) != 0x00)
+        {
+            return null;
+        }
+        return derSequence(Arrays.copyOfRange(data, oidStart, oidEnd));
+    }
+
+    /**
+     * Consume a SEQUENCE tag and length starting at {@code pos[0]}, advance
+     * {@code pos[0]} to the first content byte, and return the offset one past
+     * the SEQUENCE content.
+     */
+    private static int readSequenceHeader(byte[] data, int[] pos)
+    {
+        if (pos[0] >= data.length || (data[pos[0]++] & 0xFF) != 0x30)
+        {
+            throw new IllegalArgumentException("expected SEQUENCE");
+        }
+        int len = readLength(data, pos);
+        int end = pos[0] + len;
+        if (end > data.length)
+        {
+            throw new IllegalArgumentException("SEQUENCE length overrun");
+        }
+        return end;
+    }
+
+    /** Skip a single (single-byte-tag) TLV, advancing {@code pos[0]} past it. */
+    private static void skipTlv(byte[] data, int[] pos)
+    {
+        if (pos[0] >= data.length)
+        {
+            throw new IllegalArgumentException("truncated TLV");
+        }
+        pos[0]++;   // tag
+        int len = readLength(data, pos);
+        pos[0] += len;
+        if (pos[0] > data.length)
+        {
+            throw new IllegalArgumentException("TLV length overrun");
+        }
+    }
+
+    private static int readLength(byte[] data, int[] pos)
+    {
+        if (pos[0] >= data.length)
+        {
+            throw new IllegalArgumentException("truncated length");
+        }
+        int b = data[pos[0]++] & 0xFF;
+        if ((b & 0x80) == 0)
+        {
+            return b;
+        }
+        int count = b & 0x7F;
+        if (count == 0 || count > 4)
+        {
+            throw new IllegalArgumentException("unsupported length");
+        }
+        int len = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (pos[0] >= data.length)
+            {
+                throw new IllegalArgumentException("truncated length");
+            }
+            len = (len << 8) | (data[pos[0]++] & 0xFF);
+        }
+        if (len < 0)
+        {
+            throw new IllegalArgumentException("length out of range");
+        }
+        return len;
+    }
+
+    private static byte[] derSequence(byte[] content)
+    {
+        return Arrays.concatenate(new byte[]{0x30}, derLength(content.length), content);
+    }
+
+    private static byte[] derLength(int len)
+    {
+        if (len < 0x80)
+        {
+            return new byte[]{(byte) len};
+        }
+        if (len < 0x100)
+        {
+            return new byte[]{(byte) 0x81, (byte) len};
+        }
+        if (len < 0x10000)
+        {
+            return new byte[]{(byte) 0x82, (byte) (len >>> 8), (byte) len};
+        }
+        if (len < 0x1000000)
+        {
+            return new byte[]{(byte) 0x83, (byte) (len >>> 16), (byte) (len >>> 8), (byte) len};
+        }
+        return new byte[]{(byte) 0x84, (byte) (len >>> 24), (byte) (len >>> 16), (byte) (len >>> 8), (byte) len};
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/asn1/KeyInfoCanonicalizerTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/asn1/KeyInfoCanonicalizerTest.java
@@ -1,0 +1,275 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.asn1;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.util.asn1.KeyInfoCanonicalizer;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+
+/**
+ * The JSL KeyFactory must canonicalise an ML-DSA / SLH-DSA / ML-KEM key whose
+ * AlgorithmIdentifier carries an explicit NULL {@code parameters} element (as
+ * emitted by, e.g., {@code sun.security.x509.X509Key} when it re-encodes a key
+ * for an algorithm it does not recognise). FIPS 203/204/205 require the
+ * parameters to be absent and OpenSSL rejects the NULL form, so the KeyFactory
+ * strips it before handing the bytes to OpenSSL (see
+ * {@link org.openssl.jostle.util.asn1.KeyInfoCanonicalizer}).
+ *
+ * <p>For each algorithm this generates a (conformant) keypair, injects a NULL
+ * into both the SubjectPublicKeyInfo and the PrivateKeyInfo, and asserts that
+ * re-importing the NULL-padded encoding succeeds and re-encodes back to the
+ * original canonical form.
+ */
+public class KeyInfoCanonicalizerTest
+{
+    @BeforeAll
+    public static void before()
+    {
+        synchronized (JostleProvider.class)
+        {
+            if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+            {
+                Security.addProvider(new JostleProvider());
+            }
+        }
+    }
+
+    @Test
+    public void mldsa()
+        throws Exception
+    {
+        run("ML-DSA-44");
+    }
+
+    @Test
+    public void slhdsa()
+        throws Exception
+    {
+        run("SLH-DSA-SHA2-128F");
+    }
+
+    @Test
+    public void mlkem()
+        throws Exception
+    {
+        run("ML-KEM-768");
+    }
+
+    // -----------------------------------------------------------------
+    // Direct synthetic unit tests of the canonicaliser's branches: an exact
+    // NULL parameters element is stripped, and any other shape is returned
+    // byte-for-byte unchanged (the negative / pass-through path that the
+    // round-trip tests above can't reach, since a JSL-generated key is always
+    // already conformant).
+    // -----------------------------------------------------------------
+
+    private static final byte[] OID = {0x06, 0x03, 0x55, 0x04, 0x03};       // a placeholder OID TLV (2.5.4.3)
+    private static final byte[] NULL_PARAMS = {0x05, 0x00};
+    private static final byte[] BIT_STRING = {0x03, 0x02, 0x00, 0x2A};      // dummy subjectPublicKey
+
+    @Test
+    public void spki_nullParameters_stripped()
+    {
+        byte[] withNull = derSequence(concat(derSequence(concat(OID, NULL_PARAMS)), BIT_STRING));
+        byte[] stripped = derSequence(concat(derSequence(OID), BIT_STRING));
+        Assertions.assertArrayEquals(stripped, KeyInfoCanonicalizer.subjectPublicKeyInfo(withNull),
+                "stray NULL parameters were not stripped from the SPKI AlgorithmIdentifier");
+    }
+
+    @Test
+    public void spki_nonNullParameters_returnedUnchanged()
+    {
+        byte[] param = {0x02, 0x01, 0x01};                                  // INTEGER 1 (not a NULL)
+        byte[] spki = derSequence(concat(derSequence(concat(OID, param)), BIT_STRING));
+        Assertions.assertArrayEquals(spki, KeyInfoCanonicalizer.subjectPublicKeyInfo(spki),
+                "non-NULL parameters must be left untouched");
+    }
+
+    @Test
+    public void spki_noParameters_returnedUnchanged()
+    {
+        byte[] spki = derSequence(concat(derSequence(OID), BIT_STRING));
+        Assertions.assertArrayEquals(spki, KeyInfoCanonicalizer.subjectPublicKeyInfo(spki),
+                "already-conformant SPKI must be left untouched");
+    }
+
+    @Test
+    public void spki_malformed_returnedUnchanged()
+    {
+        byte[] notASequence = {0x05, 0x00, 0x01, 0x02};
+        Assertions.assertArrayEquals(notASequence, KeyInfoCanonicalizer.subjectPublicKeyInfo(notASequence),
+                "non-SEQUENCE input must be returned unchanged");
+        byte[] truncated = {0x30, 0x05, 0x30, 0x03, 0x06};                  // length claims more than present
+        Assertions.assertArrayEquals(truncated, KeyInfoCanonicalizer.subjectPublicKeyInfo(truncated),
+                "truncated input must be returned unchanged");
+    }
+
+    @Test
+    public void pkcs8_nullParameters_stripped()
+    {
+        byte[] version = {0x02, 0x01, 0x00};                                // INTEGER 0
+        byte[] privateKey = {0x04, 0x02, (byte) 0xAA, (byte) 0xBB};         // OCTET STRING privateKey
+        byte[] withNull = derSequence(concat(concat(version, derSequence(concat(OID, NULL_PARAMS))), privateKey));
+        byte[] stripped = derSequence(concat(concat(version, derSequence(OID)), privateKey));
+        Assertions.assertArrayEquals(stripped, KeyInfoCanonicalizer.privateKeyInfo(withNull),
+                "stray NULL parameters were not stripped from the PrivateKeyInfo AlgorithmIdentifier");
+    }
+
+    @Test
+    public void pkcs8_nonNullParameters_returnedUnchanged()
+    {
+        byte[] version = {0x02, 0x01, 0x00};
+        byte[] param = {0x02, 0x01, 0x01};
+        byte[] privateKey = {0x04, 0x02, (byte) 0xAA, (byte) 0xBB};
+        byte[] pki = derSequence(concat(concat(version, derSequence(concat(OID, param))), privateKey));
+        Assertions.assertArrayEquals(pki, KeyInfoCanonicalizer.privateKeyInfo(pki),
+                "non-NULL parameters must be left untouched");
+    }
+
+    private void run(String alg)
+        throws Exception
+    {
+        KeyPair kp = KeyPairGenerator.getInstance(alg, JostleProvider.PROVIDER_NAME).generateKeyPair();
+        KeyFactory kf = KeyFactory.getInstance(alg, JostleProvider.PROVIDER_NAME);
+
+        // SubjectPublicKeyInfo path.
+        byte[] canonicalSpki = kp.getPublic().getEncoded();
+        byte[] paddedSpki = injectNullParams(canonicalSpki, false);
+        Assertions.assertFalse(Arrays.equals(canonicalSpki, paddedSpki), alg + ": NULL injection was a no-op");
+        PublicKey pub = kf.generatePublic(new X509EncodedKeySpec(paddedSpki));
+        Assertions.assertArrayEquals(canonicalSpki, pub.getEncoded(), alg + ": SPKI not canonicalised");
+
+        // PrivateKeyInfo path.
+        byte[] canonicalPkcs8 = kp.getPrivate().getEncoded();
+        byte[] paddedPkcs8 = injectNullParams(canonicalPkcs8, true);
+        Assertions.assertFalse(Arrays.equals(canonicalPkcs8, paddedPkcs8), alg + ": NULL injection was a no-op");
+        PrivateKey priv = kf.generatePrivate(new PKCS8EncodedKeySpec(paddedPkcs8));
+        Assertions.assertArrayEquals(canonicalPkcs8, priv.getEncoded(), alg + ": PKCS8 not canonicalised");
+    }
+
+    /**
+     * Insert an explicit NULL ({@code 05 00}) as the AlgorithmIdentifier
+     * parameters. {@code isPkcs8 == false} treats {@code der} as a
+     * SubjectPublicKeyInfo (AlgorithmIdentifier is the first element);
+     * {@code isPkcs8 == true} treats it as a PrivateKeyInfo (AlgorithmIdentifier
+     * follows the version INTEGER).
+     */
+    private static byte[] injectNullParams(byte[] der, boolean isPkcs8)
+    {
+        int[] pos = {0};
+        int outerEnd = readSequenceHeader(der, pos);
+
+        byte[] prefix;
+        if (isPkcs8)
+        {
+            int versionStart = pos[0];
+            int[] vp = {versionStart};
+            skipTlv(der, vp);                       // version INTEGER
+            prefix = copyOfRange(der, versionStart, vp[0]);
+            pos[0] = vp[0];
+        }
+        else
+        {
+            prefix = new byte[0];
+        }
+
+        int[] algPos = {pos[0]};
+        int algEnd = readSequenceHeader(der, algPos);
+        byte[] algContent = copyOfRange(der, algPos[0], algEnd);
+        byte[] newAlg = derSequence(concat(algContent, new byte[]{0x05, 0x00}));
+        byte[] rest = copyOfRange(der, algEnd, outerEnd);
+
+        return derSequence(concat(concat(prefix, newAlg), rest));
+    }
+
+    private static int readSequenceHeader(byte[] data, int[] pos)
+    {
+        if ((data[pos[0]++] & 0xFF) != 0x30)
+        {
+            throw new IllegalArgumentException("expected SEQUENCE");
+        }
+        int len = readLength(data, pos);
+        return pos[0] + len;
+    }
+
+    private static void skipTlv(byte[] data, int[] pos)
+    {
+        pos[0]++;   // tag
+        int len = readLength(data, pos);
+        pos[0] += len;
+    }
+
+    private static int readLength(byte[] data, int[] pos)
+    {
+        int b = data[pos[0]++] & 0xFF;
+        if ((b & 0x80) == 0)
+        {
+            return b;
+        }
+        int count = b & 0x7F;
+        int len = 0;
+        for (int i = 0; i < count; i++)
+        {
+            len = (len << 8) | (data[pos[0]++] & 0xFF);
+        }
+        return len;
+    }
+
+    private static byte[] derSequence(byte[] content)
+    {
+        return concat(concat(new byte[]{0x30}, derLength(content.length)), content);
+    }
+
+    private static byte[] derLength(int len)
+    {
+        if (len < 0x80)
+        {
+            return new byte[]{(byte) len};
+        }
+        if (len < 0x100)
+        {
+            return new byte[]{(byte) 0x81, (byte) len};
+        }
+        if (len < 0x10000)
+        {
+            return new byte[]{(byte) 0x82, (byte) (len >>> 8), (byte) len};
+        }
+        return new byte[]{(byte) 0x83, (byte) (len >>> 16), (byte) (len >>> 8), (byte) len};
+    }
+
+    private static byte[] copyOfRange(byte[] a, int from, int to)
+    {
+        byte[] out = new byte[to - from];
+        System.arraycopy(a, from, out, 0, out.length);
+        return out;
+    }
+
+    private static byte[] concat(byte[] a, byte[] b)
+    {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
@@ -11,13 +11,30 @@
 
 package org.openssl.jostle.test.cert;
 
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.DERBitString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x509.TBSCertificate;
+import org.bouncycastle.asn1.x509.Time;
+import org.bouncycastle.asn1.x509.V1TBSCertificateGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.util.Arrays;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
@@ -31,6 +48,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -44,19 +62,22 @@ import java.util.List;
  * <ol>
  *   <li>the factory resolves against the JSL provider by both "X.509" and the
  *       "X509" alias,</li>
- *   <li>{@code getPublicKey()} returns a JSL key (not the SUN key) for both RSA
- *       and EC certificates,</li>
- *   <li>that JSL key actually verifies the certificate's own (self-signed)
+ *   <li>{@code getPublicKey()} returns a JSL key (not the SUN key) for RSA, EC
+ *       and the post-quantum (ML-DSA / SLH-DSA / ML-KEM) schemes, the latter
+ *       re-derived through the JSL provider via the SubjectPublicKeyInfo
+ *       algorithm OID,</li>
+ *   <li>that JSL key actually verifies the certificate's (self- or CA-) signed
  *       signature through a JSL {@link Signature} — and a tampered TBS does
  *       NOT verify (negative path),</li>
  *   <li>the bulk {@code generateCertificates} and {@code generateCertPath}
  *       entry points round-trip.</li>
  * </ol>
  *
- * <p>The two test certificates are self-signed leaves generated offline with
- * OpenSSL (SHA256withRSA / SHA256withECDSA) and embedded as base64 DER so the
- * test needs no PKIX cert-builder dependency (only bcprov is on the test
- * classpath).
+ * <p>The RSA and EC certificates are self-signed leaves generated offline with
+ * OpenSSL (SHA256withRSA / SHA256withECDSA) and embedded as base64 DER. The
+ * post-quantum certificates are built at runtime — bcprov's ASN.1 layer for the
+ * certificate structure, the JSL provider for signing — so the test still needs
+ * no PKIX cert-builder dependency (only bcprov is on the test classpath).
  */
 public class X509CertificateFactoryTest
 {
@@ -195,6 +216,124 @@ public class X509CertificateFactoryTest
         assertPublicKeyIsJslAndVerifies(cert);
     }
 
+    // -----------------------------------------------------------------
+    // Post-quantum certificates: the SubjectPublicKeyInfo / signature OID must
+    // resolve to a JSL KeyFactory / Signature so getPublicKey() returns a JSL
+    // key (see the OID aliases in ProvMLDSA / ProvSLHDSA / ProvMLKEM and the
+    // OID-keyed import in JSLKeyX509Certificate). Built at runtime because no
+    // PQC cert fixtures exist; bcprov's ASN.1 layer supplies the cert structure
+    // and the JSL provider does the signing.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testMldsaCert_publicKeyIsJslAndVerifiesSelfSignature() throws Exception
+    {
+        KeyPair kp = KeyPairGenerator.getInstance("ML-DSA-44", JostleProvider.PROVIDER_NAME).generateKeyPair();
+        byte[] der = buildPqcCert(kp.getPublic().getEncoded(), "ML-DSA-44",
+                "2.16.840.1.101.3.4.3.17", kp.getPrivate());
+        X509Certificate cert = parse(der);
+
+        PublicKey pub = cert.getPublicKey();
+        Assertions.assertTrue(pub.getClass().getName().startsWith("org.openssl.jostle"),
+                "getPublicKey() did not return a JSL key, was: " + pub.getClass().getName());
+        assertCertSignatureVerifies(cert, pub, "ML-DSA-44");
+    }
+
+    @Test
+    public void testSlhdsaCert_publicKeyIsJslAndVerifiesSelfSignature() throws Exception
+    {
+        KeyPair kp = KeyPairGenerator.getInstance("SLH-DSA-SHA2-128F", JostleProvider.PROVIDER_NAME).generateKeyPair();
+        byte[] der = buildPqcCert(kp.getPublic().getEncoded(), "SLH-DSA-SHA2-128F",
+                "2.16.840.1.101.3.4.3.21", kp.getPrivate());
+        X509Certificate cert = parse(der);
+
+        PublicKey pub = cert.getPublicKey();
+        Assertions.assertTrue(pub.getClass().getName().startsWith("org.openssl.jostle"),
+                "getPublicKey() did not return a JSL key, was: " + pub.getClass().getName());
+        assertCertSignatureVerifies(cert, pub, "SLH-DSA-SHA2-128F");
+    }
+
+    @Test
+    public void testMlkemCert_publicKeyResolvedThroughJslByOid() throws Exception
+    {
+        // ML-KEM is a KEM, not a signature scheme: the cert carries an ML-KEM
+        // subject key but is signed by an ML-DSA CA. The subject key must still
+        // be re-derived through the JSL KeyFactory keyed on the ML-KEM SPKI OID
+        // (2.16.840.1.101.3.4.4.2), and the ML-DSA signature must verify.
+        KeyPair caKp = KeyPairGenerator.getInstance("ML-DSA-44", JostleProvider.PROVIDER_NAME).generateKeyPair();
+        KeyPair kemKp = KeyPairGenerator.getInstance("ML-KEM-768", JostleProvider.PROVIDER_NAME).generateKeyPair();
+        byte[] der = buildPqcCert(kemKp.getPublic().getEncoded(), "ML-DSA-44",
+                "2.16.840.1.101.3.4.3.17", caKp.getPrivate());
+        X509Certificate cert = parse(der);
+
+        PublicKey pub = cert.getPublicKey();
+        Assertions.assertTrue(pub.getClass().getName().startsWith("org.openssl.jostle"),
+                "getPublicKey() did not return a JSL key, was: " + pub.getClass().getName());
+        Assertions.assertArrayEquals(kemKp.getPublic().getEncoded(), pub.getEncoded(),
+                "ML-KEM subject key did not round-trip through the JSL KeyFactory");
+        assertCertSignatureVerifies(cert, caKp.getPublic(), "ML-DSA-44");
+    }
+
+    /**
+     * Verify {@code cert}'s signature over its TBS with {@code verifyKey} through
+     * a JSL {@link Signature} named {@code sigAlg}, and prove the verify actually
+     * consumes the bytes: a tampered TBS must NOT verify (negative path).
+     */
+    private static void assertCertSignatureVerifies(X509Certificate cert, PublicKey verifyKey, String sigAlg)
+            throws Exception
+    {
+        byte[] tbs = cert.getTBSCertificate();
+        byte[] sig = cert.getSignature();
+
+        Signature verifier = Signature.getInstance(sigAlg, JostleProvider.PROVIDER_NAME);
+        verifier.initVerify(verifyKey);
+        verifier.update(tbs);
+        Assertions.assertTrue(verifier.verify(sig),
+                sigAlg + ": JSL key failed to verify the certificate signature");
+
+        byte[] tamperedTbs = Arrays.clone(tbs);
+        tamperedTbs[tamperedTbs.length / 2] ^= 0x01;
+        Signature verifier2 = Signature.getInstance(sigAlg, JostleProvider.PROVIDER_NAME);
+        verifier2.initVerify(verifyKey);
+        verifier2.update(tamperedTbs);
+        Assertions.assertFalse(verifier2.verify(sig),
+                sigAlg + ": tampered TBS unexpectedly verified");
+    }
+
+    /**
+     * Assemble a minimal X.509 v1 certificate carrying {@code subjectSpki} as its
+     * SubjectPublicKeyInfo, signed by {@code signerKey} through the JSL
+     * {@link Signature} {@code sigAlgName}, with {@code sigOid} as the
+     * signatureAlgorithm OID. Self-signed when {@code signerKey} matches the
+     * subject key.
+     */
+    private static byte[] buildPqcCert(byte[] subjectSpki, String sigAlgName, String sigOid, PrivateKey signerKey)
+            throws Exception
+    {
+        AlgorithmIdentifier sigAlgId = new AlgorithmIdentifier(new ASN1ObjectIdentifier(sigOid));
+
+        V1TBSCertificateGenerator tbsGen = new V1TBSCertificateGenerator();
+        tbsGen.setSerialNumber(new ASN1Integer(BigInteger.valueOf(1)));
+        tbsGen.setSignature(sigAlgId);
+        tbsGen.setIssuer(new X500Name("CN=Jostle PQC Test"));
+        tbsGen.setStartDate(new Time(new Date(1700000000000L)));
+        tbsGen.setEndDate(new Time(new Date(1900000000000L)));
+        tbsGen.setSubject(new X500Name("CN=Jostle PQC Test"));
+        tbsGen.setSubjectPublicKeyInfo(SubjectPublicKeyInfo.getInstance(ASN1Primitive.fromByteArray(subjectSpki)));
+        TBSCertificate tbs = tbsGen.generateTBSCertificate();
+
+        Signature signer = Signature.getInstance(sigAlgName, JostleProvider.PROVIDER_NAME);
+        signer.initSign(signerKey);
+        signer.update(tbs.getEncoded(ASN1Encoding.DER));
+        byte[] sig = signer.sign();
+
+        ASN1EncodableVector v = new ASN1EncodableVector();
+        v.add(tbs);
+        v.add(sigAlgId);
+        v.add(new DERBitString(sig));
+        return new DERSequence(v).getEncoded(ASN1Encoding.DER);
+    }
+
     /**
      * The wrapped certificate's public key must come from the JSL provider,
      * and it must verify the certificate's own (self-signed) signature when
@@ -218,7 +357,7 @@ public class X509CertificateFactoryTest
                 cert.getSigAlgName() + ": JSL key failed to verify the cert's self-signature");
 
         // Negative: flip a byte in the TBS — verification must fail.
-        byte[] tamperedTbs = tbs.clone();
+        byte[] tamperedTbs = Arrays.clone(tbs);
         tamperedTbs[tamperedTbs.length / 2] ^= 0x01;
         Signature verifier2 = Signature.getInstance(cert.getSigAlgName(), JostleProvider.PROVIDER_NAME);
         verifier2.initVerify(pub);

--- a/jostle/src/test/java/org/openssl/jostle/test/provider/PQCOidAliasTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/provider/PQCOidAliasTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.provider;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.security.KeyFactory;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+
+/**
+ * The PQC providers register NIST CSOR / RFC 9814 OID aliases so that an X.509
+ * certificate whose SubjectPublicKeyInfo (or signatureAlgorithm) carries the OID
+ * resolves to the JSL KeyFactory / Signature rather than falling back to the JDK
+ * default (see {@code JSLKeyX509Certificate} and the {@code Prov*} configure
+ * methods).
+ *
+ * <p>These aliases are wired by hand (ML-DSA / ML-KEM) or by a positional
+ * {@code algNames[i] -> oids[i]} loop (SLH-DSA), so the failure modes are: a
+ * mistyped OID string (alias missing → no service resolves), a wrong arc (e.g.
+ * ML-KEM under the {@code .4.3} "sigAlgs" arc instead of the {@code .4.4} "kems"
+ * arc), or a shifted positional pairing (OID resolves, but to the WRONG
+ * parameter set). All three are silent at runtime and invisible to a positive
+ * round-trip test that uses the algorithm <em>name</em>.
+ *
+ * <p>The assertions read the provider's own {@code Alg.Alias.<type>.<oid>}
+ * mapping table — the exact wiring {@code addAlias} writes and {@code getService}
+ * resolves through — so every OID's primary-name pairing is checked without
+ * per-parameter-set keygen/signing (SLH-DSA "S" variants are slow). A shifted
+ * pairing surfaces as a mismatched primary name; a mistyped/wrong-arc OID
+ * surfaces as a missing entry. A separate smoke test confirms the aliases are
+ * actually constructible via {@code getInstance}. The OID strings are duplicated
+ * verbatim from the provider source on purpose: the test is the independent
+ * second copy that a single-sided edit must disagree with.
+ */
+public class PQCOidAliasTest
+{
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    @Test
+    public void mldsaOidAliases()
+    {
+        // NIST CSOR id-ml-dsa-44/65/87 — both KeyFactory and Signature.
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.3.17", "ML-DSA-44");
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.3.18", "ML-DSA-65");
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.3.19", "ML-DSA-87");
+        assertAlias("Signature", "2.16.840.1.101.3.4.3.17", "ML-DSA-44");
+        assertAlias("Signature", "2.16.840.1.101.3.4.3.18", "ML-DSA-65");
+        assertAlias("Signature", "2.16.840.1.101.3.4.3.19", "ML-DSA-87");
+    }
+
+    @Test
+    public void mlkemOidAliases()
+    {
+        // RFC 9814 id-alg-ml-kem-* live under the .4.4 "kems" arc, NOT .4.3
+        // "sigAlgs"; ML-KEM is a KEM, so KeyFactory only (no Signature).
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.4.1", "ML-KEM-512");
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.4.2", "ML-KEM-768");
+        assertAlias("KeyFactory", "2.16.840.1.101.3.4.4.3", "ML-KEM-1024");
+    }
+
+    @Test
+    public void slhdsaOidAliases()
+    {
+        // NIST CSOR id-slh-dsa-* (.20..31), in declaration order. Both
+        // KeyFactory and Signature, paired positionally in the provider.
+        String[] names = {
+                "SLH-DSA-SHA2-128S", "SLH-DSA-SHA2-128F",
+                "SLH-DSA-SHA2-192S", "SLH-DSA-SHA2-192F",
+                "SLH-DSA-SHA2-256S", "SLH-DSA-SHA2-256F",
+                "SLH-DSA-SHAKE-128S", "SLH-DSA-SHAKE-128F",
+                "SLH-DSA-SHAKE-192S", "SLH-DSA-SHAKE-192F",
+                "SLH-DSA-SHAKE-256S", "SLH-DSA-SHAKE-256F"
+        };
+        for (int i = 0; i < names.length; i++)
+        {
+            String oid = "2.16.840.1.101.3.4.3." + (20 + i);
+            assertAlias("KeyFactory", oid, names[i]);
+            assertAlias("Signature", oid, names[i]);
+        }
+    }
+
+    @Test
+    public void oidAliasesAreUsableViaGetInstance()
+        throws Exception
+    {
+        // getService resolution (used above) and getInstance resolution share
+        // the same alias table, but prove one of each is actually constructible
+        // and reports the JSL provider.
+        KeyFactory kf = KeyFactory.getInstance("2.16.840.1.101.3.4.3.17", JostleProvider.PROVIDER_NAME);
+        Assertions.assertEquals(JostleProvider.PROVIDER_NAME, kf.getProvider().getName());
+
+        Signature sig = Signature.getInstance("2.16.840.1.101.3.4.3.17", JostleProvider.PROVIDER_NAME);
+        Assertions.assertEquals(JostleProvider.PROVIDER_NAME, sig.getProvider().getName());
+
+        KeyFactory kemKf = KeyFactory.getInstance("2.16.840.1.101.3.4.4.2", JostleProvider.PROVIDER_NAME);
+        Assertions.assertEquals(JostleProvider.PROVIDER_NAME, kemKf.getProvider().getName());
+    }
+
+    private static void assertAlias(String type, String oid, String expectedPrimary)
+    {
+        Provider p = Security.getProvider(JostleProvider.PROVIDER_NAME);
+        Object mapped = p.get("Alg.Alias." + type + "." + oid);
+        Assertions.assertNotNull(mapped, type + " has no alias registered under OID " + oid);
+        Assertions.assertEquals(expectedPrimary, mapped,
+                type + " OID " + oid + " is aliased to the wrong algorithm");
+    }
+}


### PR DESCRIPTION
added OID based lookup and canonicalisation for PQC keys to deal with JVM re-encoding bug.

part of this can be dealt with by removing delegation to SUN provider certificate factory, but it's likely we'll see improperly encoded parameters for PQC keys in the wild (not least because it appears the SUN provider produces them).