### PR TITLE
Wrap CertPath certificates for JSL provider

### DIFF
--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
@@ -85,13 +85,14 @@ public class X509CertificateFactorySpi
      */
     private static Certificate wrap(Certificate c)
     {
+        // Fast-path: if it's already our wrapper, return unchanged to avoid double-wrapping.
+        if (c instanceof JSLKeyX509Certificate)
+        {
+            return c;
+        }
+
         if (c instanceof X509Certificate)
         {
-            // Avoid double-wrapping: if it's already a JSL wrapper, return as-is.
-            if (c instanceof JSLKeyX509Certificate)
-            {
-                return c;
-            }
             return new JSLKeyX509Certificate((X509Certificate) c, JostleProvider.PROVIDER_NAME);
         }
         return c;

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/cert/X509CertificateFactorySpi.java
@@ -67,7 +67,11 @@ public class X509CertificateFactorySpi
         throws CertificateException
     {
         Collection<? extends Certificate> certs = delegate.generateCertificates(inStream);
-        List<Certificate> wrapped = new ArrayList<Certificate>(certs.size());
+        if (certs == null || certs.isEmpty())
+        {
+            return certs;
+        }
+        List<Certificate> wrapped = new ArrayList<>(certs.size());
         for (Certificate c : certs)
         {
             wrapped.add(wrap(c));
@@ -83,6 +87,11 @@ public class X509CertificateFactorySpi
     {
         if (c instanceof X509Certificate)
         {
+            // Avoid double-wrapping: if it's already a JSL wrapper, return as-is.
+            if (c instanceof JSLKeyX509Certificate)
+            {
+                return c;
+            }
             return new JSLKeyX509Certificate((X509Certificate) c, JostleProvider.PROVIDER_NAME);
         }
         return c;
@@ -103,19 +112,50 @@ public class X509CertificateFactorySpi
     public CertPath engineGenerateCertPath(InputStream inStream)
         throws CertificateException
     {
-        return delegate.generateCertPath(inStream);
+        CertPath parsed = delegate.generateCertPath(inStream);
+        List<? extends Certificate> certs = parsed.getCertificates();
+        if (certs == null || certs.isEmpty())
+        {
+            return parsed;
+        }
+        List<Certificate> wrapped = new ArrayList<>(certs.size());
+        for (Certificate c : certs)
+        {
+            wrapped.add(wrap(c));
+        }
+        return delegate.generateCertPath(wrapped);
     }
 
     public CertPath engineGenerateCertPath(InputStream inStream, String encoding)
         throws CertificateException
     {
-        return delegate.generateCertPath(inStream, encoding);
+        CertPath parsed = delegate.generateCertPath(inStream, encoding);
+        List<? extends Certificate> certs = parsed.getCertificates();
+        if (certs == null || certs.isEmpty())
+        {
+            return parsed;
+        }
+        List<Certificate> wrapped = new ArrayList<>(certs.size());
+        for (Certificate c : certs)
+        {
+            wrapped.add(wrap(c));
+        }
+        return delegate.generateCertPath(wrapped);
     }
 
     public CertPath engineGenerateCertPath(List<? extends Certificate> certificates)
         throws CertificateException
     {
-        return delegate.generateCertPath(certificates);
+        if (certificates == null || certificates.isEmpty())
+        {
+            return delegate.generateCertPath(certificates);
+        }
+        List<Certificate> wrapped = new ArrayList<>(certificates.size());
+        for (Certificate c : certificates)
+        {
+            wrapped.add(wrap(c));
+        }
+        return delegate.generateCertPath(wrapped);
     }
 
     public java.util.Iterator<String> engineGetCertPathEncodings()

--- a/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/cert/X509CertificateFactoryTest.java
@@ -406,11 +406,15 @@ public class X509CertificateFactoryTest
         list.add(parse(rsaCertDer()));
         CertPath path = cf.generateCertPath(list);
         Assertions.assertEquals(1, path.getCertificates().size());
+        Assertions.assertTrue(path.getCertificates().get(0).getPublicKey().getClass().getName().startsWith("org.openssl.jostle"),
+                "generateCertPath(List) element returned a non-JSL key");
 
         // Encode then re-parse — the encoded form must round-trip back to an
         // equal cert list through the same factory.
         byte[] encoded = path.getEncoded();
         CertPath reparsed = cf.generateCertPath(new ByteArrayInputStream(encoded));
+        Assertions.assertTrue(reparsed.getCertificates().get(0).getPublicKey().getClass().getName().startsWith("org.openssl.jostle"),
+                "generateCertPath(InputStream) element returned a non-JSL key");
         Assertions.assertArrayEquals(
                 list.get(0).getEncoded(),
                 reparsed.getCertificates().get(0).getEncoded(),


### PR DESCRIPTION
1. Rebuilt CertPath from wrapped certificates in all engineGenerateCertPath() variants so returned CertPath objects contain JSL-backed certificates
2. Made wrap() idempotent (return input if already wrapped)
3. Added an assertion check in tests