### PR TITLE
added support for named lookup, NONEwithRSA, NONEwithECDSA, digest cloning

### DIFF
--- a/interface/ffi/md_ffi.c
+++ b/interface/ffi/md_ffi.c
@@ -28,6 +28,13 @@ md_ctx *MD_Allocate(const char *digest_name, int32_t xof_len, int32_t *err) {
     return ctx;
 }
 
+md_ctx *MD_Copy(md_ctx *src, int32_t *err) {
+    jo_assert(err != NULL);
+    jo_assert(src != NULL);
+
+    return md_ctx_copy(src, err);
+}
+
 void MD_Dispose(md_ctx *ctx) {
     if (ctx == NULL) {
         return;

--- a/interface/jni/md_jni.c
+++ b/interface/jni/md_jni.c
@@ -63,6 +63,32 @@ exit:
 
 /*
  * Class:     org_openssl_jostle_jcajce_provider_md_MDServiceJNI
+ * Method:    ni_copyDigest
+ * Signature: (J[I)J
+ */
+JNIEXPORT jlong JNICALL Java_org_openssl_jostle_jcajce_provider_md_MDServiceJNI_ni_1copyDigest
+(JNIEnv *env, jobject jo, jlong ref, jintArray _err) {
+    UNUSED(jo);
+
+    int32_t *err = NULL;
+    md_ctx *new_ctx = NULL;
+
+    jo_assert(_err != NULL);
+    err = (*env)->GetIntArrayElements(env, _err, NULL);
+    jo_assert(err != NULL);
+
+    md_ctx *ctx = (md_ctx *) ref;
+    jo_assert(ctx != NULL);
+
+    new_ctx = md_ctx_copy(ctx, err);
+
+    (*env)->ReleaseIntArrayElements(env, _err, err, 0);
+
+    return (jlong) new_ctx;
+}
+
+/*
+ * Class:     org_openssl_jostle_jcajce_provider_md_MDServiceJNI
  * Method:    ni_updateByte
  * Signature: (JB)I
  */

--- a/interface/util/asn1_util.c
+++ b/interface/util/asn1_util.c
@@ -349,14 +349,15 @@ int32_t asn1_writer_encode_private_key(asn1_ctx *ctx, key_spec *key_spec, size_t
 
     switch (encoding_option) {
         case PRIVATE_KEY_DEFAULT_ENCODING:
-            // EC keys go through the OSSL_ENCODER PKCS#8 path so the
+            // EC and RSA keys go through the OSSL_ENCODER PKCS#8 path so the
             // emitted bytes are an actual PKCS#8 PrivateKeyInfo (matching
-            // getFormat()="PKCS#8") rather than the SEC1 ECPrivateKey
-            // that i2d_PrivateKey_bio would default to. All other key
-            // types stay on the legacy i2d path — for RSA / Ed / PQC
-            // that already produces what callers expect (round-trip and
-            // BC interop tests confirm).
-            if (EVP_PKEY_is_a(key_spec->key, "EC")) {
+            // getFormat()="PKCS#8") rather than the "traditional" form that
+            // i2d_PrivateKey_bio defaults to — SEC1 ECPrivateKey for EC, and
+            // the PKCS#1 RSAPrivateKey for RSA. Ed25519/Ed448 and the PQC
+            // types have no traditional form, so i2d_PrivateKey already emits
+            // PKCS#8 for them and they stay on the legacy path.
+            if (EVP_PKEY_is_a(key_spec->key, "EC")
+                || EVP_PKEY_is_a(key_spec->key, "RSA")) {
                 if (OPS_OPENSSL_ERROR_4 1 != encode_private_key_pkcs8(ctx, key_spec)) {
                     return 0;
                 }

--- a/interface/util/bc_err_codes.h
+++ b/interface/util/bc_err_codes.h
@@ -161,6 +161,14 @@
  */
 #define JO_CURVE_NOT_SUPPORTED -114
 
+/*
+ * EVP_MD_CTX_copy_ex failed while cloning a digest context (md_ctx_copy).
+ * Distinct from JO_MD_CREATE_FAILED (EVP_MD_CTX_new failure) so the clone
+ * path's failure is identifiable. Surfaces as the CloneNotSupportedException
+ * cause at the MessageDigest.clone() boundary.
+ */
+#define JO_MD_COPY_FAILED -115
+
 
 
 #define UNSUCCESSFUL(x) JO_SUCCESS > x

--- a/interface/util/ec.c
+++ b/interface/util/ec.c
@@ -448,7 +448,96 @@ void ec_ctx_destroy(ec_ctx *ctx) {
     if (ctx->digest_ctx != NULL) {
         EVP_MD_CTX_free(ctx->digest_ctx);
     }
+    if (ctx->raw_pctx != NULL) {
+        EVP_PKEY_CTX_free(ctx->raw_pctx);
+    }
+    if (ctx->raw_buf != NULL) {
+        OPENSSL_clear_free(ctx->raw_buf, ctx->raw_buf_cap);
+    }
     OPENSSL_clear_free(ctx, sizeof(*ctx));
+}
+
+
+/*
+ * Free all per-session state on the ctx, returning it to the freshly-created
+ * state (no digest_ctx, no raw session, opp == 0). NULL-tolerant on every
+ * field. Called at the top of init_sign / init_verify and from ec_ctx_destroy.
+ */
+static void ec_ctx_clear_session(ec_ctx *ctx) {
+    if (ctx->digest_ctx != NULL) {
+        EVP_MD_CTX_free(ctx->digest_ctx);
+        ctx->digest_ctx = NULL;
+    }
+    if (ctx->raw_pctx != NULL) {
+        EVP_PKEY_CTX_free(ctx->raw_pctx);
+        ctx->raw_pctx = NULL;
+    }
+    if (ctx->raw_buf != NULL) {
+        OPENSSL_clear_free(ctx->raw_buf, ctx->raw_buf_cap);
+        ctx->raw_buf = NULL;
+    }
+    ctx->raw_buf_len = 0;
+    ctx->raw_buf_cap = 0;
+    ctx->opp = 0;
+}
+
+/*
+ * Initialise the raw ECDSA ("NoneWithECDSA") session: an EVP_PKEY_CTX set up
+ * for EVP_PKEY_sign / EVP_PKEY_verify with no EVP_MD, so OpenSSL treats the
+ * caller-supplied bytes as the already-computed digest. ECDSA has no padding,
+ * so there is nothing else to configure. Caller has already cleared prior
+ * session state via ec_ctx_clear_session.
+ */
+static int32_t ec_raw_init(ec_ctx *ctx, OSSL_LIB_CTX *libctx,
+                           EVP_PKEY *key, int op) {
+    EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, NULL);
+    if (OPS_OPENSSL_ERROR_11 pctx == NULL) {
+        return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_11(3100);
+    }
+
+    int init_rc = (op == EC_OP_SIGN)
+                      ? EVP_PKEY_sign_init(pctx)
+                      : EVP_PKEY_verify_init(pctx);
+    if (1 != init_rc) {
+        EVP_PKEY_CTX_free(pctx);
+        return JO_OPENSSL_ERROR;
+    }
+
+    ctx->raw_pctx = pctx;
+    ctx->opp = op;
+    return JO_SUCCESS;
+}
+
+/*
+ * Append caller-supplied bytes to the raw-mode buffer (the pre-computed digest
+ * that EVP_PKEY_sign / EVP_PKEY_verify consumes one-shot). Grows geometrically;
+ * the total is bounded to INT32_MAX so the eventual int cast can't overflow.
+ */
+static int32_t ec_raw_append(ec_ctx *ctx, const uint8_t *in, size_t in_len) {
+    if (in_len > (size_t) INT32_MAX) {
+        return JO_INPUT_TOO_LONG_INT32;
+    }
+    if (ctx->raw_buf_len > (size_t) INT32_MAX - in_len) {
+        return JO_INPUT_TOO_LONG_INT32;
+    }
+
+    size_t need = ctx->raw_buf_len + in_len;
+    if (need > ctx->raw_buf_cap) {
+        size_t new_cap = ctx->raw_buf_cap != 0 ? ctx->raw_buf_cap : 64;
+        while (new_cap < need) {
+            new_cap *= 2;
+        }
+        uint8_t *nb = OPENSSL_realloc(ctx->raw_buf, new_cap);
+        jo_assert(nb != NULL);
+        ctx->raw_buf = nb;
+        ctx->raw_buf_cap = new_cap;
+    }
+
+    if (in_len > 0) {
+        memcpy(ctx->raw_buf + ctx->raw_buf_len, in, in_len);
+    }
+    ctx->raw_buf_len = need;
+    return JO_SUCCESS;
 }
 
 
@@ -479,11 +568,13 @@ int32_t ec_ctx_init_sign(ec_ctx *ctx, const key_spec *key,
     EVP_PKEY_CTX *pctx = NULL;       // not owned — owned by md_ctx
 
     // Free any prior session state up-front (rsa_ctx_init_sign rationale).
-    if (ctx->digest_ctx != NULL) {
-        EVP_MD_CTX_free(ctx->digest_ctx);
-        ctx->digest_ctx = NULL;
+    ec_ctx_clear_session(ctx);
+
+    // Raw ECDSA ("NoneWithECDSA") — no streaming digest; buffer the
+    // caller-supplied digest and sign it one-shot in ec_ctx_sign.
+    if (strcmp(digest_name, "NONE") == 0) {
+        return ec_raw_init(ctx, libctx, key->key, EC_OP_SIGN);
     }
-    ctx->opp = 0;
 
     // Reuses OPS_OPENSSL_ERROR_3 / _4. Each test drives only one path.
     md_ctx = EVP_MD_CTX_new();
@@ -535,11 +626,12 @@ int32_t ec_ctx_init_verify(ec_ctx *ctx, const key_spec *key,
     EVP_MD_CTX *md_ctx = NULL;
     EVP_PKEY_CTX *pctx = NULL;
 
-    if (ctx->digest_ctx != NULL) {
-        EVP_MD_CTX_free(ctx->digest_ctx);
-        ctx->digest_ctx = NULL;
+    ec_ctx_clear_session(ctx);
+
+    // Raw ECDSA ("NoneWithECDSA") verify path — buffer + EVP_PKEY_verify.
+    if (strcmp(digest_name, "NONE") == 0) {
+        return ec_raw_init(ctx, libctx, key->key, EC_OP_VERIFY);
     }
-    ctx->opp = 0;
 
     // Reuses OPS_OPENSSL_ERROR_5 / _6. Each test drives only one path.
     md_ctx = EVP_MD_CTX_new();
@@ -576,6 +668,14 @@ int32_t ec_ctx_update(ec_ctx *ctx, const uint8_t *in, size_t in_len) {
     jo_assert(in != NULL);
     jo_assert(in_len <= (size_t) INT32_MAX);
 
+    // Raw ECDSA: accumulate the caller-supplied digest, no streaming hash.
+    if (ctx->raw_pctx != NULL) {
+        if (ctx->opp != EC_OP_SIGN && ctx->opp != EC_OP_VERIFY) {
+            return JO_UNEXPECTED_STATE;
+        }
+        return ec_raw_append(ctx, in, in_len);
+    }
+
     if (ctx->digest_ctx == NULL) {
         return JO_NOT_INITIALIZED;
     }
@@ -607,6 +707,38 @@ int32_t ec_ctx_sign(ec_ctx *ctx, uint8_t *out, size_t out_len,
     jo_assert(ctx != NULL);
 
     jo_assert(rnd_src != NULL);
+
+    // Raw ECDSA ("NoneWithECDSA"): one-shot EVP_PKEY_sign over the buffered
+    // caller-supplied digest. ECDSA is randomised, so rnd_src feeds the nonce.
+    if (ctx->raw_pctx != NULL) {
+        if (ctx->opp != EC_OP_SIGN) {
+            return JO_UNEXPECTED_STATE;
+        }
+        rand_set_java_srand_call(rnd_src);
+        ERR_clear_error();
+
+        size_t raw_sig_len = 0;
+        if (OPS_OPENSSL_ERROR_12 1 != EVP_PKEY_sign(ctx->raw_pctx, NULL, &raw_sig_len,
+                               ctx->raw_buf, ctx->raw_buf_len)) {
+            return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_12(3101);
+        }
+        if (raw_sig_len > (size_t) INT32_MAX) {
+            return JO_OUTPUT_TOO_LONG_INT32;
+        }
+        if (out == NULL) {
+            return (int32_t) raw_sig_len;
+        }
+        if (raw_sig_len > out_len) {
+            return JO_OUTPUT_TOO_SMALL;
+        }
+        // ECDSA DER length varies; the first call returned an upper bound and
+        // the second writes the actual length back into raw_sig_len.
+        if (1 != EVP_PKEY_sign(ctx->raw_pctx, out, &raw_sig_len,
+                               ctx->raw_buf, ctx->raw_buf_len)) {
+            return JO_OPENSSL_ERROR;
+        }
+        return (int32_t) raw_sig_len;
+    }
 
     if (ctx->digest_ctx == NULL) {
         return JO_NOT_INITIALIZED;
@@ -663,6 +795,34 @@ int32_t ec_ctx_verify(ec_ctx *ctx, const uint8_t *sig, size_t sig_len,
     jo_assert(sig_len <= (size_t) INT32_MAX);
 
     jo_assert(rnd_src != NULL);
+
+    // Raw ECDSA ("NoneWithECDSA"): one-shot EVP_PKEY_verify of the DER
+    // signature against the buffered caller-supplied digest.
+    if (ctx->raw_pctx != NULL) {
+        if (ctx->opp != EC_OP_VERIFY) {
+            return JO_UNEXPECTED_STATE;
+        }
+        rand_set_java_srand_call(rnd_src);
+        ERR_clear_error();
+        ERR_set_mark();
+        int raw_ret = EVP_PKEY_verify(ctx->raw_pctx, sig, sig_len,
+                                      ctx->raw_buf, ctx->raw_buf_len);
+        // OPS: force the structural-error (-1) branch.
+        if (OPS_OPENSSL_ERROR_11 0) {
+            ERR_clear_last_mark();
+            return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_11(3102);
+        }
+        if (raw_ret == 1) {
+            ERR_pop_to_mark();
+            return JO_SUCCESS;
+        } else if (raw_ret == 0) {
+            ERR_pop_to_mark();
+            return JO_FAIL;
+        } else {
+            ERR_clear_last_mark();
+            return JO_OPENSSL_ERROR;
+        }
+    }
 
     if (ctx->digest_ctx == NULL) {
         return JO_NOT_INITIALIZED;

--- a/interface/util/ec.h
+++ b/interface/util/ec.h
@@ -121,6 +121,14 @@ int32_t ec_make_private_from_components(key_spec *spec,
 typedef struct ec_ctx {
     EVP_MD_CTX *digest_ctx;
     int opp;            // EC_OP_SIGN | EC_OP_VERIFY
+    // Raw ECDSA ("NoneWithECDSA", digest name "NONE") session state: the
+    // caller supplies an already-computed digest, which is buffered and
+    // signed/verified one-shot via EVP_PKEY_sign/EVP_PKEY_verify (no EVP_MD).
+    // Mutually exclusive with digest_ctx — exactly one is set after init.
+    EVP_PKEY_CTX *raw_pctx;
+    uint8_t *raw_buf;
+    size_t raw_buf_len;
+    size_t raw_buf_cap;
 } ec_ctx;
 
 ec_ctx *ec_ctx_create(int32_t *err);

--- a/interface/util/md.c
+++ b/interface/util/md.c
@@ -90,6 +90,46 @@ md_ctx *md_ctx_create(const char *name, int xof_len, int *err) {
     return ctx;
 }
 
+md_ctx *md_ctx_copy(const md_ctx *src, int *err) {
+    // The bridge validates the source handle; util asserts it as an invariant.
+    jo_assert(src != NULL);
+    jo_assert(src->mdctx != NULL);
+    jo_assert(src->md_type != NULL);
+    ERR_clear_error();
+
+    EVP_MD_CTX *new_mdctx = EVP_MD_CTX_new();
+    if (new_mdctx == NULL) {
+        *err = JO_MD_CREATE_FAILED;
+        return NULL;
+    }
+
+    // EVP_MD_CTX_copy_ex snapshots the in-progress digest state (the absorbed
+    // bytes), which is exactly what a MessageDigest.clone() needs.
+    if (!EVP_MD_CTX_copy_ex(new_mdctx, src->mdctx)) {
+        EVP_MD_CTX_free(new_mdctx);
+        *err = JO_MD_COPY_FAILED;
+        return NULL;
+    }
+
+    // The copy carries its own reference to the algorithm descriptor so the
+    // clone's md_ctx_destroy is balanced (md_ctx_destroy frees md_type).
+    if (!EVP_MD_up_ref((EVP_MD *) src->md_type)) {
+        EVP_MD_CTX_free(new_mdctx);
+        *err = JO_MD_COPY_FAILED;
+        return NULL;
+    }
+
+    md_ctx *ctx = OPENSSL_zalloc(sizeof(md_ctx));
+    jo_assert(ctx != NULL);
+    ctx->md_type = src->md_type;
+    ctx->mdctx = new_mdctx;
+    ctx->digest_byte_length = src->digest_byte_length;
+    ctx->xof = src->xof;
+
+    *err = JO_SUCCESS;
+    return ctx;
+}
+
 void md_ctx_destroy(md_ctx *ctx) {
     if (ctx == NULL) {
         return;

--- a/interface/util/md.c
+++ b/interface/util/md.c
@@ -98,14 +98,14 @@ md_ctx *md_ctx_copy(const md_ctx *src, int *err) {
     ERR_clear_error();
 
     EVP_MD_CTX *new_mdctx = EVP_MD_CTX_new();
-    if (new_mdctx == NULL) {
+    if (OPS_FAILED_CREATE_2 new_mdctx == NULL) {
         *err = JO_MD_CREATE_FAILED;
         return NULL;
     }
 
     // EVP_MD_CTX_copy_ex snapshots the in-progress digest state (the absorbed
     // bytes), which is exactly what a MessageDigest.clone() needs.
-    if (!EVP_MD_CTX_copy_ex(new_mdctx, src->mdctx)) {
+    if (OPS_OPENSSL_ERROR_11 !EVP_MD_CTX_copy_ex(new_mdctx, src->mdctx)) {
         EVP_MD_CTX_free(new_mdctx);
         *err = JO_MD_COPY_FAILED;
         return NULL;
@@ -113,7 +113,7 @@ md_ctx *md_ctx_copy(const md_ctx *src, int *err) {
 
     // The copy carries its own reference to the algorithm descriptor so the
     // clone's md_ctx_destroy is balanced (md_ctx_destroy frees md_type).
-    if (!EVP_MD_up_ref((EVP_MD *) src->md_type)) {
+    if (OPS_OPENSSL_ERROR_12 !EVP_MD_up_ref((EVP_MD *) src->md_type)) {
         EVP_MD_CTX_free(new_mdctx);
         *err = JO_MD_COPY_FAILED;
         return NULL;

--- a/interface/util/md.h
+++ b/interface/util/md.h
@@ -21,6 +21,7 @@
     } md_ctx;
 
     md_ctx * md_ctx_create(const char*name, int xof_len, int *err);
+    md_ctx * md_ctx_copy(const md_ctx *src, int *err);
     void md_ctx_destroy(md_ctx *ctx);
     int32_t md_ctx_update(md_ctx *ctx, uint8_t *data, size_t len);
     int32_t md_ctx_finalize(md_ctx *ctx, uint8_t *digest);

--- a/interface/util/rsa.c
+++ b/interface/util/rsa.c
@@ -496,8 +496,106 @@ void rsa_ctx_destroy(rsa_ctx *ctx) {
     if (ctx->digest_ctx != NULL) {
         EVP_MD_CTX_free(ctx->digest_ctx);
     }
+    if (ctx->raw_pctx != NULL) {
+        EVP_PKEY_CTX_free(ctx->raw_pctx);
+    }
+    if (ctx->raw_buf != NULL) {
+        OPENSSL_clear_free(ctx->raw_buf, ctx->raw_buf_cap);
+    }
 
     OPENSSL_clear_free(ctx, sizeof(*ctx));
+}
+
+
+/*
+ * Free all per-session state on the ctx and return it to the "freshly
+ * created" state (opp == 0, padding_mode == 0, no digest_ctx, no raw
+ * session). Called at the top of init_sign / init_verify so a failed
+ * (re-)init can't leave a half-configured context behind, and from
+ * rsa_ctx_destroy. NULL-tolerant on every field.
+ */
+static void rsa_ctx_clear_session(rsa_ctx *ctx) {
+    if (ctx->digest_ctx != NULL) {
+        EVP_MD_CTX_free(ctx->digest_ctx);
+        ctx->digest_ctx = NULL;
+    }
+    if (ctx->raw_pctx != NULL) {
+        EVP_PKEY_CTX_free(ctx->raw_pctx);
+        ctx->raw_pctx = NULL;
+    }
+    if (ctx->raw_buf != NULL) {
+        OPENSSL_clear_free(ctx->raw_buf, ctx->raw_buf_cap);
+        ctx->raw_buf = NULL;
+    }
+    ctx->raw_buf_len = 0;
+    ctx->raw_buf_cap = 0;
+    ctx->opp = 0;
+    ctx->padding_mode = 0;
+}
+
+/*
+ * Initialise the raw PKCS#1 v1.5 ("NoneWithRSA") session: an EVP_PKEY_CTX
+ * set up for EVP_PKEY_sign / EVP_PKEY_verify with RSA_PKCS1_PADDING and NO
+ * signature md, so OpenSSL pads the caller-supplied bytes directly. Caller
+ * has already cleared prior session state via rsa_ctx_clear_session.
+ */
+static int32_t rsa_raw_init(rsa_ctx *ctx, OSSL_LIB_CTX *libctx,
+                            EVP_PKEY *key, int op) {
+    EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, NULL);
+    if (pctx == NULL) {
+        return JO_OPENSSL_ERROR;
+    }
+
+    int init_rc = (op == RSA_OP_SIGN)
+                      ? EVP_PKEY_sign_init(pctx)
+                      : EVP_PKEY_verify_init(pctx);
+    if (1 != init_rc) {
+        EVP_PKEY_CTX_free(pctx);
+        return JO_OPENSSL_ERROR;
+    }
+
+    if (1 != EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PADDING)) {
+        EVP_PKEY_CTX_free(pctx);
+        return JO_OPENSSL_ERROR;
+    }
+
+    ctx->raw_pctx = pctx;
+    ctx->opp = op;
+    ctx->padding_mode = RSA_PADDING_PKCS1_NONE;
+    return JO_SUCCESS;
+}
+
+/*
+ * Append caller-supplied bytes to the raw-mode buffer (the TBS that
+ * EVP_PKEY_sign / EVP_PKEY_verify will consume one-shot). Grows the buffer
+ * geometrically; the total is bounded to INT32_MAX so the eventual cast to
+ * int on the Java return path can't overflow.
+ */
+static int32_t rsa_raw_append(rsa_ctx *ctx, const uint8_t *in, size_t in_len) {
+    if (in_len > (size_t) INT_MAX) {
+        return JO_INPUT_TOO_LONG_INT32;
+    }
+    if (ctx->raw_buf_len > (size_t) INT_MAX - in_len) {
+        return JO_INPUT_TOO_LONG_INT32;
+    }
+
+    size_t need = ctx->raw_buf_len + in_len;
+    if (need > ctx->raw_buf_cap) {
+        size_t new_cap = ctx->raw_buf_cap != 0 ? ctx->raw_buf_cap : 64;
+        while (new_cap < need) {
+            new_cap *= 2;
+        }
+        uint8_t *nb = OPENSSL_realloc(ctx->raw_buf, new_cap);
+        jo_assert(nb != NULL);
+        ctx->raw_buf = nb;
+        ctx->raw_buf_cap = new_cap;
+    }
+
+    if (in_len > 0) {
+        memcpy(ctx->raw_buf + ctx->raw_buf_len, in, in_len);
+    }
+    ctx->raw_buf_len = need;
+    return JO_SUCCESS;
 }
 
 
@@ -576,14 +674,16 @@ int32_t rsa_ctx_init_sign(rsa_ctx *ctx, const key_spec *key,
     EVP_PKEY_CTX *pctx = NULL;       // not owned — owned by md_ctx
 
     // Free any prior session state up-front. If init then fails partway,
-    // ctx->digest_ctx stays NULL so subsequent rsa_ctx_update / _sign /
-    // _verify return JO_NOT_INITIALIZED rather than dispatching into a
-    // half-configured digest_ctx (undefined behaviour inside libcrypto).
-    if (ctx->digest_ctx != NULL) {
-        EVP_MD_CTX_free(ctx->digest_ctx);
-        ctx->digest_ctx = NULL;
+    // ctx stays cleared so subsequent rsa_ctx_update / _sign / _verify
+    // return JO_NOT_INITIALIZED rather than dispatching into a
+    // half-configured context (undefined behaviour inside libcrypto).
+    rsa_ctx_clear_session(ctx);
+
+    // Raw PKCS#1 v1.5 ("NoneWithRSA") has no streaming digest — set up an
+    // EVP_PKEY_CTX and buffer input until rsa_ctx_sign.
+    if (padding_mode == RSA_PADDING_PKCS1_NONE) {
+        return rsa_raw_init(ctx, libctx, key->key, RSA_OP_SIGN);
     }
-    ctx->opp = 0;
 
     md_ctx = EVP_MD_CTX_new();
     if (OPS_OPENSSL_ERROR_1 md_ctx == NULL) {
@@ -646,11 +746,12 @@ int32_t rsa_ctx_init_verify(rsa_ctx *ctx, const key_spec *key,
     EVP_PKEY_CTX *pctx = NULL;       // not owned — owned by md_ctx
 
     // Clear prior session state up-front (see rsa_ctx_init_sign for why).
-    if (ctx->digest_ctx != NULL) {
-        EVP_MD_CTX_free(ctx->digest_ctx);
-        ctx->digest_ctx = NULL;
+    rsa_ctx_clear_session(ctx);
+
+    // Raw PKCS#1 v1.5 ("NoneWithRSA") verify path — buffer + EVP_PKEY_verify.
+    if (padding_mode == RSA_PADDING_PKCS1_NONE) {
+        return rsa_raw_init(ctx, libctx, key->key, RSA_OP_VERIFY);
     }
-    ctx->opp = 0;
 
     md_ctx = EVP_MD_CTX_new();
     if (OPS_OPENSSL_ERROR_1 md_ctx == NULL) {
@@ -690,6 +791,17 @@ int32_t rsa_ctx_update(rsa_ctx *ctx, const uint8_t *in, size_t in_len) {
     jo_assert(ctx != NULL);
     jo_assert(in != NULL);
 
+    // Raw PKCS#1 v1.5: accumulate into the buffer, no streaming digest.
+    if (ctx->padding_mode == RSA_PADDING_PKCS1_NONE) {
+        if (ctx->raw_pctx == NULL) {
+            return JO_NOT_INITIALIZED;
+        }
+        if (ctx->opp != RSA_OP_SIGN && ctx->opp != RSA_OP_VERIFY) {
+            return JO_UNEXPECTED_STATE;
+        }
+        return rsa_raw_append(ctx, in, in_len);
+    }
+
     if (ctx->digest_ctx == NULL) {
         return JO_NOT_INITIALIZED;
     }
@@ -728,6 +840,45 @@ int32_t rsa_ctx_sign(rsa_ctx *ctx, uint8_t *out, size_t out_len,
 
     if (rnd_src == NULL) {
         return JO_RAND_NO_RAND_UP_CALL;
+    }
+
+    // Raw PKCS#1 v1.5 ("NoneWithRSA"): one-shot EVP_PKEY_sign over the
+    // buffered caller-supplied bytes. PKCS#1 v1.5 signing is deterministic,
+    // so rnd_src is unused beyond the bridge's null check.
+    if (ctx->padding_mode == RSA_PADDING_PKCS1_NONE) {
+        if (ctx->raw_pctx == NULL) {
+            return JO_NOT_INITIALIZED;
+        }
+        if (ctx->opp != RSA_OP_SIGN) {
+            return JO_UNEXPECTED_STATE;
+        }
+
+        rand_set_java_srand_call(rnd_src);
+        ERR_clear_error();
+
+        size_t raw_sig_len = 0;
+        if (1 != EVP_PKEY_sign(ctx->raw_pctx, NULL, &raw_sig_len,
+                               ctx->raw_buf, ctx->raw_buf_len)) {
+            return JO_OPENSSL_ERROR;
+        }
+        if (raw_sig_len > INT32_MAX) {
+            return JO_OUTPUT_TOO_LONG_INT32;
+        }
+        if (out == NULL) {
+            return (int32_t) raw_sig_len;
+        }
+        if (raw_sig_len > out_len) {
+            return JO_OUTPUT_TOO_SMALL;
+        }
+        const size_t raw_expected = raw_sig_len;
+        if (1 != EVP_PKEY_sign(ctx->raw_pctx, out, &raw_sig_len,
+                               ctx->raw_buf, ctx->raw_buf_len)) {
+            return JO_OPENSSL_ERROR;
+        }
+        if (raw_sig_len != raw_expected) {
+            return JO_UNEXPECTED_SIG_LEN_CHANGE;
+        }
+        return (int32_t) raw_sig_len;
     }
 
     if (ctx->digest_ctx == NULL) {
@@ -776,6 +927,35 @@ int32_t rsa_ctx_sign(rsa_ctx *ctx, uint8_t *out, size_t out_len,
 int32_t rsa_ctx_verify(rsa_ctx *ctx, const uint8_t *sig, size_t sig_len) {
     jo_assert(ctx != NULL);
     jo_assert(sig != NULL);
+
+    // Raw PKCS#1 v1.5 ("NoneWithRSA"): one-shot EVP_PKEY_verify of the
+    // signature against the buffered caller-supplied bytes.
+    if (ctx->padding_mode == RSA_PADDING_PKCS1_NONE) {
+        if (ctx->raw_pctx == NULL) {
+            return JO_NOT_INITIALIZED;
+        }
+        if (ctx->opp != RSA_OP_VERIFY) {
+            return JO_UNEXPECTED_STATE;
+        }
+        if (sig_len > (size_t) INT_MAX) {
+            return JO_INPUT_TOO_LONG_INT32;
+        }
+
+        ERR_clear_error();
+        ERR_set_mark();
+        int raw_ret = EVP_PKEY_verify(ctx->raw_pctx, sig, sig_len,
+                                      ctx->raw_buf, ctx->raw_buf_len);
+        if (raw_ret == 1) {
+            ERR_pop_to_mark();
+            return JO_SUCCESS;
+        } else if (raw_ret == 0) {
+            ERR_pop_to_mark();
+            return JO_FAIL;
+        } else {
+            ERR_clear_last_mark();
+            return JO_OPENSSL_ERROR;
+        }
+    }
 
     if (ctx->digest_ctx == NULL) {
         return JO_NOT_INITIALIZED;

--- a/interface/util/rsa.c
+++ b/interface/util/rsa.c
@@ -542,8 +542,8 @@ static void rsa_ctx_clear_session(rsa_ctx *ctx) {
 static int32_t rsa_raw_init(rsa_ctx *ctx, OSSL_LIB_CTX *libctx,
                             EVP_PKEY *key, int op) {
     EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, NULL);
-    if (pctx == NULL) {
-        return JO_OPENSSL_ERROR;
+    if (OPS_OPENSSL_ERROR_11 pctx == NULL) {
+        return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_11(1100);
     }
 
     int init_rc = (op == RSA_OP_SIGN)
@@ -857,9 +857,9 @@ int32_t rsa_ctx_sign(rsa_ctx *ctx, uint8_t *out, size_t out_len,
         ERR_clear_error();
 
         size_t raw_sig_len = 0;
-        if (1 != EVP_PKEY_sign(ctx->raw_pctx, NULL, &raw_sig_len,
+        if (OPS_OPENSSL_ERROR_12 1 != EVP_PKEY_sign(ctx->raw_pctx, NULL, &raw_sig_len,
                                ctx->raw_buf, ctx->raw_buf_len)) {
-            return JO_OPENSSL_ERROR;
+            return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_12(1101);
         }
         if (raw_sig_len > INT32_MAX) {
             return JO_OUTPUT_TOO_LONG_INT32;
@@ -945,6 +945,11 @@ int32_t rsa_ctx_verify(rsa_ctx *ctx, const uint8_t *sig, size_t sig_len) {
         ERR_set_mark();
         int raw_ret = EVP_PKEY_verify(ctx->raw_pctx, sig, sig_len,
                                       ctx->raw_buf, ctx->raw_buf_len);
+        // OPS: force the structural-error (-1) branch.
+        if (OPS_OPENSSL_ERROR_11 0) {
+            ERR_clear_last_mark();
+            return JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_11(1102);
+        }
         if (raw_ret == 1) {
             ERR_pop_to_mark();
             return JO_SUCCESS;

--- a/interface/util/rsa.h
+++ b/interface/util/rsa.h
@@ -21,6 +21,12 @@
 // RSA_PKCS1_PSS_PADDING inside rsa.c.
 #define RSA_PADDING_PKCS1 1
 #define RSA_PADDING_PSS   2
+// Raw PKCS#1 v1.5 ("NoneWithRSA"): no streaming digest — the caller
+// supplies the already-formed bytes (typically a DigestInfo), which are
+// buffered and signed/verified one-shot via EVP_PKEY_sign/EVP_PKEY_verify
+// with RSA_PKCS1_PADDING and NO signature md (OpenSSL pads the input
+// directly). Used by TLS's externally-hashed CertificateVerify path.
+#define RSA_PADDING_PKCS1_NONE 3
 
 // Component selectors for rsa_get_component(). Stable identifiers
 // across the FFI/JNI boundary — do NOT renumber.
@@ -38,6 +44,12 @@ typedef struct rsa_ctx {
     EVP_MD_CTX *digest_ctx;
     int opp;            // RSA_OP_SIGN | RSA_OP_VERIFY
     int padding_mode;   // RSA_PADDING_*
+    // Raw PKCS#1 v1.5 (RSA_PADDING_PKCS1_NONE) session state. Unused by the
+    // digest-based modes (digest_ctx stays NULL when these are populated).
+    EVP_PKEY_CTX *raw_pctx;   // sign/verify ctx, padding pre-configured
+    uint8_t *raw_buf;         // accumulated caller-supplied input (the TBS)
+    size_t raw_buf_len;       // bytes used
+    size_t raw_buf_cap;       // bytes allocated
 } rsa_ctx;
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ErrorCode.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ErrorCode.java
@@ -146,6 +146,9 @@ public enum ErrorCode
     // Curve name not recognised by the loaded OpenSSL build.
     JO_CURVE_NOT_SUPPORTED(-114),
 
+    // EVP_MD_CTX_copy_ex failed while cloning a digest context.
+    JO_MD_COPY_FAILED(-115),
+
     JO_UNKNOWN(Integer.MIN_VALUE);
 
     private final int code;

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvEC.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvEC.java
@@ -10,6 +10,7 @@
 
 package org.openssl.jostle.jcajce.provider;
 
+import org.openssl.jostle.jcajce.provider.ec.ECAlgorithmParameters;
 import org.openssl.jostle.jcajce.provider.ec.ECDHKeyAgreementSpi;
 import org.openssl.jostle.jcajce.provider.ec.ECDSASignatureSpi;
 import org.openssl.jostle.jcajce.provider.ec.ECKeyFactorySpi;
@@ -47,6 +48,15 @@ class ProvEC
                 PREFIX + "ECKeyFactorySpi", attr,
                 (arg) -> new ECKeyFactorySpi());
         provider.addAlias("KeyFactory", "EC", EC_PUBLIC_KEY_OID);
+
+        // AlgorithmParameters EC — delegates curve-parameter resolution to
+        // the platform (SunEC). Needed by BouncyCastle's TLS JceTlsECDomain,
+        // which resolves NIST-curve domain parameters via
+        // createAlgorithmParameters("EC") on the JSL-bound helper.
+        provider.addAlgorithmImplementation("AlgorithmParameters", "EC",
+                PREFIX + "ECAlgorithmParameters", new HashMap<>(),
+                (arg) -> new ECAlgorithmParameters());
+        provider.addAlias("AlgorithmParameters", "EC", EC_PUBLIC_KEY_OID);
 
         // ECDSA Signature variants. The signature OIDs come from
         // RFC 5758 (SHA-2) and RFC 5754 / NIST CSOR (SHA-3). The digest

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvEC.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvEC.java
@@ -90,6 +90,14 @@ class ProvEC
                 "SHA3-512withECDSA", ECDSASignatureSpi.SHA3_512.class,
                 NISTObjectIdentifiers.id_ecdsa_with_sha3_512.getId());
 
+        // Raw ECDSA ("NoneWithECDSA"): the caller supplies an already-computed
+        // digest, so there is no per-digest OID to alias. Required by TLS 1.3's
+        // externally-hashed ECDSA CertificateVerify (BouncyCastle's
+        // JcaTlsECDSA13Signer.generateRawSignature).
+        provider.addAlgorithmImplementation("Signature", "NoneWithECDSA",
+                PREFIX + "ECDSASignatureSpi$None", attr,
+                (arg) -> new ECDSASignatureSpi.None());
+
         // ECDH KeyAgreement. The OID 1.3.132.1.12 is id-ecDH from SECG
         // (RFC 5480 §2.1.2 / SEC 1 §C.4); RFC 5480 also permits the
         // generic id-ecPublicKey OID for ECDH-with-X.509 SubjectPublicKeyInfo,

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvRSA.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvRSA.java
@@ -62,6 +62,14 @@ class ProvRSA
         registerPkcs1Signature(provider, attr,
                 "SHA3-512withRSA", "SHA3-512", RSASignatureSpi.SHA3_512.class, NISTObjectIdentifiers.id_rsassa_pkcs1_v1_5_with_sha3_512.getId());
 
+        // Raw PKCS#1 v1.5 ("NoneWithRSA"): the caller has already formed the
+        // bytes to sign (e.g. a DigestInfo), so there is no per-digest OID to
+        // alias. Required by TLS 1.3's externally-hashed RSA CertificateVerify
+        // (BouncyCastle's JcaTlsRSASigner.getRawSigner()).
+        provider.addAlgorithmImplementation("Signature", "NoneWithRSA",
+                PREFIX + "RSASignatureSpi$None", attr,
+                (arg) -> new RSASignatureSpi.None());
+
         // RSASSA-PSS — parameters carried via PSSParameterSpec.
         provider.addAlgorithmImplementation("Signature", "RSASSA-PSS",
                 PREFIX + "RSAPSSSignatureSpi", attr,

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECAlgorithmParameters.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECAlgorithmParameters.java
@@ -1,0 +1,162 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.ec;
+
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.io.IOException;
+import java.security.AlgorithmParameters;
+import java.security.AlgorithmParametersSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+
+/**
+ * {@code AlgorithmParameters} for EC. Lets callers resolve EC domain
+ * parameters from this provider by name ({@code "EC"}) or by the
+ * id-ecPublicKey OID — notably BouncyCastle's TLS layer, whose
+ * {@code JceTlsECDomain} obtains curve parameters via
+ * {@code helper.createAlgorithmParameters("EC")} on the JSL-bound helper
+ * before any NIST-curve TLS group can be negotiated.
+ *
+ * <p>The ASN.1 codec and the {@code ECParameterSpec}/{@code ECGenParameterSpec}
+ * translation are delegated to a platform EC {@code AlgorithmParameters}
+ * (SunEC on a standard JDK) — this provider has no curve list of its own.
+ *
+ * <p>Unlike {@link org.openssl.jostle.jcajce.provider.blockcipher.GCMAlgorithmParameters}
+ * (which dodges recursion by NOT registering its bare name and resolving
+ * its delegate via {@code getInstance("GCM")}), this class IS registered
+ * under the bare name {@code "EC"} because the TLS path needs that name.
+ * The delegate must therefore be resolved from a provider that is NOT
+ * Jostle, or {@code getInstance("EC")} could resolve back to this class
+ * and recurse. {@link #resolveDelegate()} walks the installed providers
+ * and skips Jostle for exactly that reason.
+ */
+public class ECAlgorithmParameters
+    extends AlgorithmParametersSpi
+{
+    private final AlgorithmParameters delegate;
+
+    public ECAlgorithmParameters()
+    {
+        this.delegate = resolveDelegate();
+    }
+
+    /**
+     * Find a platform EC {@code AlgorithmParameters} that is not this
+     * provider's, so delegation cannot recurse into this class.
+     */
+    private static AlgorithmParameters resolveDelegate()
+    {
+        for (Provider p : Security.getProviders())
+        {
+            if (JostleProvider.PROVIDER_NAME.equals(p.getName()))
+            {
+                continue;
+            }
+            if (p.getService("AlgorithmParameters", "EC") == null)
+            {
+                continue;
+            }
+            try
+            {
+                return AlgorithmParameters.getInstance("EC", p);
+            }
+            catch (NoSuchAlgorithmException e)
+            {
+                // Service advertised but not constructible from this
+                // provider — keep looking.
+            }
+        }
+        throw new IllegalStateException(
+                "no non-Jostle AlgorithmParameters(\"EC\") available from the platform");
+    }
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+        throws InvalidParameterSpecException
+    {
+        if (paramSpec instanceof ECGenParameterSpec)
+        {
+            // SunEC's ECParameters accepts only some aliases of a curve
+            // name (e.g. "secp256r1" but not "P-256" on some JDKs). Try
+            // each known alias against the delegate so any standard name
+            // for a curve resolves. Resolving against the (non-Jostle)
+            // delegate — never via getInstance("EC") — keeps this off the
+            // path that could route back into this class and recurse.
+            String name = ((ECGenParameterSpec) paramSpec).getName();
+            InvalidParameterSpecException last = null;
+            for (String candidate : ECComponents.aliasesFor(name))
+            {
+                try
+                {
+                    delegate.init(new ECGenParameterSpec(candidate));
+                    return;
+                }
+                catch (InvalidParameterSpecException e)
+                {
+                    last = e;
+                }
+            }
+            if (last != null)
+            {
+                throw last;
+            }
+            throw new InvalidParameterSpecException("unsupported EC curve: " + name);
+        }
+        delegate.init(paramSpec);
+    }
+
+    @Override
+    protected void engineInit(byte[] params)
+        throws IOException
+    {
+        delegate.init(params);
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format)
+        throws IOException
+    {
+        delegate.init(params, format);
+    }
+
+    @Override
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
+        throws InvalidParameterSpecException
+    {
+        return delegate.getParameterSpec(paramSpec);
+    }
+
+    @Override
+    protected byte[] engineGetEncoded()
+        throws IOException
+    {
+        return delegate.getEncoded();
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format)
+        throws IOException
+    {
+        return delegate.getEncoded(format);
+    }
+
+    @Override
+    protected String engineToString()
+    {
+        return delegate.toString();
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECComponents.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECComponents.java
@@ -164,6 +164,61 @@ final class ECComponents
     }
 
     /**
+     * Canonicalise a caller-supplied curve name to one the loaded
+     * OpenSSL build accepts via {@code OSSL_PKEY_PARAM_GROUP_NAME}.
+     *
+     * <p>OpenSSL does not recognise every standard name for a curve:
+     * P-256 is registered under {@code prime256v1}/{@code P-256} but NOT
+     * the SECG {@code secp256r1} nor the X9.62 OID
+     * {@code 1.2.840.10045.3.1.7}, even though those are the names TLS
+     * (and SECG) callers use. This method maps any accepted alias of a
+     * curve to a name OpenSSL does recognise.
+     *
+     * <p>Strategy: if OpenSSL already accepts the name as-given, return
+     * it unchanged (the common case, and the only behaviour for names
+     * not in the alias table). Otherwise locate the alias family the
+     * name belongs to — matching against every form, including the OID —
+     * and return the first member OpenSSL accepts. Returns {@code null}
+     * if no form of the curve is supported by the loaded build, which
+     * the caller surfaces as {@link java.security.InvalidAlgorithmParameterException}.
+     */
+    static String toOpenSSLCurveName(String requested)
+    {
+        if (requested == null)
+        {
+            return null;
+        }
+        if (NISelector.ECServiceNI.curveSupported(requested))
+        {
+            return requested;
+        }
+        for (String[] family : CURVE_ALIASES.values())
+        {
+            boolean member = false;
+            for (String alias : family)
+            {
+                if (alias.equals(requested))
+                {
+                    member = true;
+                    break;
+                }
+            }
+            if (!member)
+            {
+                continue;
+            }
+            for (String candidate : family)
+            {
+                if (NISelector.ECServiceNI.curveSupported(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Compare two {@link ECParameterSpec} instances field-by-field.
      * {@code ECParameterSpec} doesn't override {@code equals}, so this
      * is a content-based comparison over the curve, generator, order,
@@ -243,7 +298,7 @@ final class ECComponents
      * {@code switch}-with-fallthrough hazards a manual editor might
      * introduce when adding a new family.
      */
-    private static String[] aliasesFor(String curveName)
+    static String[] aliasesFor(String curveName)
     {
         String[] aliases = CURVE_ALIASES.get(curveName);
         return aliases != null ? aliases : new String[]{curveName};

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
@@ -374,4 +374,19 @@ public class ECDSASignatureSpi extends SignatureSpi
             super("SHA3-512");
         }
     }
+
+    /**
+     * Raw ECDSA — "NoneWithECDSA". The engine performs no hashing; the
+     * caller-supplied bytes (an already-computed digest) are buffered and
+     * signed/verified directly, producing/consuming a DER-encoded ECDSA
+     * signature. Required by TLS 1.3's externally-hashed ECDSA
+     * CertificateVerify (BouncyCastle's JcaTlsECDSA13Signer).
+     */
+    public static class None extends ECDSASignatureSpi
+    {
+        public None()
+        {
+            super("NONE");
+        }
+    }
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECKeyPairGenerator.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ec/ECKeyPairGenerator.java
@@ -25,6 +25,7 @@ import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,12 +75,17 @@ import java.util.Map;
  *       name through {@code ECGenParameterSpec} instead.</li>
  *   <li>{@link #initialize(AlgorithmParameterSpec)} with
  *       {@link ECGenParameterSpec} — preferred. The curve name is
- *       passed straight through to OpenSSL.</li>
+ *       canonicalised (so SECG / OID aliases OpenSSL doesn't recognise
+ *       directly, e.g. {@code secp256r1}, resolve) and passed to
+ *       OpenSSL.</li>
+ *   <li>{@link #initialize(AlgorithmParameterSpec)} with an explicit
+ *       {@link ECParameterSpec} — the supplied domain parameters are
+ *       reverse-resolved to a named curve OpenSSL recognises (standard
+ *       JCA callers build an {@code ECParameterSpec} from a named
+ *       curve). Custom curves matching no known named curve are
+ *       rejected with {@link InvalidAlgorithmParameterException}, since
+ *       OpenSSL key generation here is named-curve only.</li>
  * </ul>
- *
- * <p>Explicit-parameters form ({@code java.security.spec.ECParameterSpec})
- * is not supported in this initial cut; callers that need a non-named
- * curve should use OpenSSL directly.
  */
 public class ECKeyPairGenerator extends KeyPairGenerator
 {
@@ -146,27 +152,48 @@ public class ECKeyPairGenerator extends KeyPairGenerator
         {
             throw new InvalidAlgorithmParameterException("AlgorithmParameterSpec is null");
         }
-        if (!(params instanceof ECGenParameterSpec))
+
+        String resolved;
+        if (params instanceof ECGenParameterSpec)
         {
-            // ECParameterSpec (explicit-parameters form) is not supported
-            // in this cut. Tell callers what to do instead.
-            throw new InvalidAlgorithmParameterException(
-                    "expected ECGenParameterSpec (got " + params.getClass().getName()
-                            + "). Explicit-parameter ECParameterSpec is not supported "
-                            + "— use a named curve.");
+            String name = ((ECGenParameterSpec) params).getName();
+            if (name == null || name.isEmpty())
+            {
+                throw new InvalidAlgorithmParameterException(
+                        "ECGenParameterSpec name is null or empty");
+            }
+            // Canonicalise so SECG/OID aliases OpenSSL doesn't recognise
+            // directly (e.g. "secp256r1", "1.2.840.10045.3.1.7") resolve
+            // to a name it accepts.
+            resolved = ECComponents.toOpenSSLCurveName(name);
+            if (resolved == null)
+            {
+                throw new InvalidAlgorithmParameterException(
+                        "curve '" + name + "' is not supported by the loaded OpenSSL build");
+            }
         }
-        String name = ((ECGenParameterSpec) params).getName();
-        if (name == null || name.isEmpty())
+        else if (params instanceof ECParameterSpec)
+        {
+            // Explicit-parameters form. OpenSSL key generation here is
+            // named-curve only, so reverse-resolve the supplied domain
+            // parameters to a curve name OpenSSL recognises.
+            resolved = ECComponents.findCurveName((ECParameterSpec) params);
+            if (resolved == null)
+            {
+                throw new InvalidAlgorithmParameterException(
+                        "explicit EC parameters do not match any named curve "
+                                + "supported by the loaded OpenSSL build; "
+                                + "use a named curve via ECGenParameterSpec");
+            }
+        }
+        else
         {
             throw new InvalidAlgorithmParameterException(
-                    "ECGenParameterSpec name is null or empty");
+                    "expected ECGenParameterSpec or ECParameterSpec (got "
+                            + params.getClass().getName() + ")");
         }
-        if (!ecServiceNI.curveSupported(name))
-        {
-            throw new InvalidAlgorithmParameterException(
-                    "curve '" + name + "' is not supported by the loaded OpenSSL build");
-        }
-        this.curveName = name;
+
+        this.curveName = resolved;
         this.random = DefaultRandSource.replaceWith(this.random, random);
     }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdKeyFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdKeyFactorySpi.java
@@ -196,7 +196,113 @@ public class EdKeyFactorySpi extends KeyFactorySpi
         {
             return key;
         }
+        if (key instanceof PublicKey)
+        {
+            return importPublicKey((PublicKey) key);
+        }
+        if (key instanceof PrivateKey)
+        {
+            return importPrivateKey((PrivateKey) key);
+        }
         throw new InvalidKeyException("Invalid Key: " + key);
+    }
+
+    /**
+     * Adopt an EdDSA public key produced by another provider (SunEC's
+     * {@code EdECPublicKey}, BouncyCastle's EdDSA key, etc.) as a
+     * Jostle-native {@link JOEdPublicKey} by re-decoding its X.509
+     * SubjectPublicKeyInfo. Jostle keys are returned unchanged. This is
+     * what lets {@code Signature.getInstance("Ed25519","JSL").initVerify(k)}
+     * accept a foreign-decoded public key — the case BouncyCastle's TLS
+     * layer hits when a peer certificate's key was decoded by a different
+     * provider (GH issue: JCA/TLS gap #5).
+     */
+    static JOEdPublicKey importPublicKey(PublicKey key) throws InvalidKeyException
+    {
+        if (key == null)
+        {
+            throw new InvalidKeyException("public key is null");
+        }
+        if (key instanceof JOEdPublicKey)
+        {
+            return (JOEdPublicKey) key;
+        }
+        byte[] encoded = key.getEncoded();
+        if (encoded == null)
+        {
+            throw new InvalidKeyException(
+                    "cannot import EdDSA public key: no X.509 encoding available from "
+                            + key.getClass().getName());
+        }
+        try
+        {
+            PKEYKeySpec pkeySpec = ASN1Encoder.fromSubjectPublicKeyInfo(encoded, 0, encoded.length);
+            switch (pkeySpec.getType())
+            {
+                case ED25519:
+                case ED448:
+                    return new JOEdPublicKey(pkeySpec);
+                default:
+                    throw new InvalidKeyException(
+                            "not an EdDSA public key: " + pkeySpec.getType());
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            throw e;
+        }
+        catch (RuntimeException e)
+        {
+            throw new InvalidKeyException(
+                    "unable to import EdDSA public key from its encoding", e);
+        }
+    }
+
+    /**
+     * Counterpart of {@link #importPublicKey(PublicKey)} for private
+     * keys: re-decodes a foreign EdDSA private key's PKCS#8
+     * PrivateKeyInfo into a Jostle-native {@link JOEdPrivateKey}. Jostle
+     * keys are returned unchanged.
+     */
+    static JOEdPrivateKey importPrivateKey(PrivateKey key) throws InvalidKeyException
+    {
+        if (key == null)
+        {
+            throw new InvalidKeyException("private key is null");
+        }
+        if (key instanceof JOEdPrivateKey)
+        {
+            return (JOEdPrivateKey) key;
+        }
+        byte[] encoded = key.getEncoded();
+        if (encoded == null)
+        {
+            throw new InvalidKeyException(
+                    "cannot import EdDSA private key: no PKCS#8 encoding available from "
+                            + key.getClass().getName());
+        }
+        try
+        {
+            PKEYKeySpec pkeySpec = ASN1Encoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
+            switch (pkeySpec.getType())
+            {
+                case ED25519:
+                case ED448:
+                    return new JOEdPrivateKey(pkeySpec);
+                default:
+                    throw new InvalidKeyException(
+                            "not an EdDSA private key: " + pkeySpec.getType());
+            }
+        }
+        catch (InvalidKeyException e)
+        {
+            throw e;
+        }
+        catch (RuntimeException e)
+        {
+            throw new InvalidKeyException(
+                    "unable to import EdDSA private key from its encoding", e);
+        }
     }
 
     public static class ED25519 extends EdKeyFactorySpi

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdKeyFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdKeyFactorySpi.java
@@ -13,6 +13,7 @@ package org.openssl.jostle.jcajce.provider.ed;
 
 import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.*;
+import org.openssl.jostle.util.Arrays;
 import org.openssl.jostle.util.asn1.ASN1Encoder;
 
 import java.security.*;
@@ -101,25 +102,37 @@ public class EdKeyFactorySpi extends KeyFactorySpi
         if (keySpec instanceof PKCS8EncodedKeySpec)
         {
 
+            // PKCS8EncodedKeySpec.getEncoded() returns a fresh copy carrying
+            // the private scalar — scrub it once the native key is built.
             byte[] encoded = ((PKCS8EncodedKeySpec) keySpec).getEncoded();
 
-            PKEYKeySpec pkeySpec = ASN1Encoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
-
-            if (fixedType != OSSLKeyType.NONE && fixedType != pkeySpec.getType())
+            try
             {
-                throw new InvalidKeySpecException("expected " + fixedType.getAlgorithmName() + " but got " + pkeySpec.getType());
-            }
+                PKEYKeySpec pkeySpec = ASN1Encoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
 
-            switch (pkeySpec.getType())
+                if (fixedType != OSSLKeyType.NONE && fixedType != pkeySpec.getType())
+                {
+                    throw new InvalidKeySpecException("expected " + fixedType.getAlgorithmName() + " but got " + pkeySpec.getType());
+                }
+
+                switch (pkeySpec.getType())
+                {
+                    case ED25519:
+                    case ED448:
+                        break;
+                    default:
+                        throw new InvalidKeySpecException("expected ED key but got " + pkeySpec.getType());
+                }
+
+                return new JOEdPrivateKey(pkeySpec);
+            }
+            finally
             {
-                case ED25519:
-                case ED448:
-                    break;
-                default:
-                    throw new InvalidKeySpecException("expected ED key but got " + pkeySpec.getType());
+                if (encoded != null)
+                {
+                    Arrays.fill(encoded, (byte) 0);
+                }
             }
-
-            return new JOEdPrivateKey(pkeySpec);
         }
         else
         {
@@ -133,13 +146,25 @@ public class EdKeyFactorySpi extends KeyFactorySpi
                     throw new InvalidKeySpecException("Invalid KeySpec: " + keySpec);
                 }
 
+                // getPrivateData() returns Arrays.clone(...) — a fresh copy of
+                // the raw scalar — so scrubbing it can't corrupt the caller's spec.
                 byte[] encoded = spec.getPrivateData();
 
-                PKEYKeySpec pkeySpec = new PKEYKeySpec(NISelector.SpecNI.allocate(), osslKeyType);
-                NISelector.EDServiceNI.decode_privateKey(
-                        pkeySpec.getReference(), osslKeyType.getKsType(),
-                        encoded, 0, encoded.length);
-                return new JOEdPrivateKey(pkeySpec);
+                try
+                {
+                    PKEYKeySpec pkeySpec = new PKEYKeySpec(NISelector.SpecNI.allocate(), osslKeyType);
+                    NISelector.EDServiceNI.decode_privateKey(
+                            pkeySpec.getReference(), osslKeyType.getKsType(),
+                            encoded, 0, encoded.length);
+                    return new JOEdPrivateKey(pkeySpec);
+                }
+                finally
+                {
+                    if (encoded != null)
+                    {
+                        Arrays.fill(encoded, (byte) 0);
+                    }
+                }
             }
         }
 
@@ -302,6 +327,14 @@ public class EdKeyFactorySpi extends KeyFactorySpi
         {
             throw new InvalidKeyException(
                     "unable to import EdDSA private key from its encoding", e);
+        }
+        finally
+        {
+            // The PKCS#8 encoding carries the private scalar — scrub our copy
+            // once the native key has been built. getEncoded() returned a
+            // fresh array (non-null, checked above), so this can't corrupt the
+            // caller's key. Arrays.fill is not null-safe, but encoded != null.
+            Arrays.fill(encoded, (byte) 0);
         }
     }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
@@ -78,49 +78,46 @@ public class EdSignatureSpi extends SignatureSpi
 
         synchronized (this)
         {
-            if ((publicKey instanceof EdDSAPublicKey))
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their X.509 encoding, so a
+            // verify with a public key decoded by another provider works
+            // (JCA/TLS gap #5).
+            JOEdPublicKey key = EdKeyFactorySpi.importPublicKey(publicKey);
+
+            updateCalled = false;
+            lastKey = key;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                updateCalled = false;
-
-
-                JOEdPublicKey key = (JOEdPublicKey) publicKey;
-                lastKey = key;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), publicKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
-            throw new InvalidKeyException("expected only EdDSAPublicKey");
+
+            if (ref == null)
+            {
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
+            }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
         }
     }
 
@@ -135,52 +132,49 @@ public class EdSignatureSpi extends SignatureSpi
     {
         this.randSource = DefaultRandSource.replaceWith(this.randSource, secureRandom);
 
-        if (privateKey instanceof EdDSAPrivateKey)
+        synchronized (this)
         {
-            synchronized (this)
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their PKCS#8 encoding
+            // (JCA/TLS gap #5).
+            JOEdPrivateKey key = EdKeyFactorySpi.importPrivateKey(privateKey);
+            lastKey = key;
+            updateCalled = false;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                JOEdPrivateKey key = (JOEdPrivateKey) privateKey;
-                lastKey = key;
-                updateCalled = false;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), privateKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initSign(
-                        ref.getReference(),
-                        key.getSpec().getReference(), name, context, contextLen, randSource);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
+
+            if (ref == null)
+            {
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
+            }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initSign(
+                    ref.getReference(),
+                    key.getSpec().getReference(), name, context, contextLen, randSource);
         }
-        throw new InvalidKeyException("expected only EdDSAPrivateKey");
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/JOEdPrivateKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/JOEdPrivateKey.java
@@ -39,7 +39,8 @@ public class JOEdPrivateKey extends AsymmetricKeyImpl implements EdDSAPrivateKey
     @Override
     public String getAlgorithm()
     {
-        return getType().getAlgorithmName();
+        // Canonical JCA name ("Ed25519"/"Ed448", mixed case) — matches SunEC/BC.
+        return getType().getTypeName();
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/JOEdPublicKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ed/JOEdPublicKey.java
@@ -28,7 +28,10 @@ public class JOEdPublicKey extends AsymmetricKeyImpl implements EdDSAPublicKey
     @Override
     public String getAlgorithm()
     {
-        return getType().getAlgorithmName();
+        // Canonical JCA name ("Ed25519"/"Ed448", mixed case) — matches SunEC/BC
+        // so consumers that dispatch on getAlgorithm() (e.g. BC's TLS
+        // JcaTlsCertificate.getPubKeyEd25519) recognise the key.
+        return getType().getTypeName();
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceJNI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceJNI.java
@@ -18,6 +18,10 @@ public class MDServiceJNI implements MDServiceNI
 
 
     @Override
+    native public long ni_copyDigest(long ref, int[] err);
+
+
+    @Override
     native public int ni_updateByte(long ref, byte b);
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceNI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceNI.java
@@ -20,6 +20,8 @@ public interface MDServiceNI extends DefaultServiceNI
 
     long ni_allocateDigest(String name, int xofLen, int[] err);
 
+    long ni_copyDigest(long ref, int[] err);
+
     int ni_updateByte(long ref, byte b);
 
     int ni_updateBytes(long ref, byte[] input, int offset, int len);
@@ -38,6 +40,17 @@ public interface MDServiceNI extends DefaultServiceNI
     {
         int[] err = new int[1];
         long v = ni_allocateDigest(name, xofLen, err);
+        handleErrors(err[0]);
+        return v;
+    }
+
+
+    // Clone the native digest state (EVP_MD_CTX_copy_ex). Returns a fresh
+    // native handle that the caller wraps in its own NativeReference/Disposer.
+    default long copyDigest(long ref)
+    {
+        int[] err = new int[1];
+        long v = ni_copyDigest(ref, err);
         handleErrors(err[0]);
         return v;
     }
@@ -95,6 +108,8 @@ public interface MDServiceNI extends DefaultServiceNI
                 throw new IllegalStateException("md unable to set param");
             case JO_MD_XOF_LEN_INVALID:
                 throw new IllegalArgumentException("xof length inconsistent with algorithm");
+            case JO_MD_COPY_FAILED:
+                throw new IllegalStateException("md copy failed");
             default:
                 return baseErrorHandler(code);
         }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceSPI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/md/MDServiceSPI.java
@@ -18,11 +18,12 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import java.security.DigestException;
 import java.security.MessageDigestSpi;
 
-public class MDServiceSPI extends MessageDigestSpi
+public class MDServiceSPI extends MessageDigestSpi implements Cloneable
 {
     private static final MDServiceNI mdServiceNI = NISelector.MDServiceNI;
 
     private final MDReference ref;
+    private final String algorithm;
 
     public MDServiceSPI(String algorithm)
     {
@@ -30,6 +31,7 @@ public class MDServiceSPI extends MessageDigestSpi
         //
         // algoritm name must be something that OpenSSL can resolve
         //
+        this.algorithm = algorithm;
         this.ref = new MDReference(mdServiceNI.allocateDigest(algorithm, 0), algorithm);
     }
 
@@ -38,7 +40,20 @@ public class MDServiceSPI extends MessageDigestSpi
         //
         // algoritm name must be something that OpenSSL can resolve
         //
+        this.algorithm = algorithm;
         this.ref = new MDReference(mdServiceNI.allocateDigest(algorithm, xofLen), algorithm);
+    }
+
+    //
+    // Wrapping constructor for clone(): adopts an already-allocated native
+    // digest context (a copy produced by MDServiceNI.copyDigest). Distinct
+    // from the (String, int xofLen) constructor, which *allocates* a fresh
+    // context — this one takes ownership of an existing MDReference.
+    //
+    private MDServiceSPI(String algorithm, MDReference clonedRef)
+    {
+        this.algorithm = algorithm;
+        this.ref = clonedRef;
     }
 
 
@@ -106,6 +121,23 @@ public class MDServiceSPI extends MessageDigestSpi
         synchronized (this)
         {
             return mdServiceNI.getDigestOutputLen(ref.getReference());
+        }
+    }
+
+    //
+    // MessageDigest.clone() routes here (the JCA Delegate calls Object.clone()
+    // on the SPI when it is Cloneable). A shallow Object.clone() would share
+    // the single native EVP_MD_CTX between the original and the copy — a
+    // double-free and cross-talk hazard — so we deep-copy the native state via
+    // EVP_MD_CTX_copy_ex and hand the clone its own MDReference/Disposer.
+    //
+    @Override
+    public Object clone() throws CloneNotSupportedException
+    {
+        synchronized (this)
+        {
+            long clonedRef = mdServiceNI.copyDigest(ref.getReference());
+            return new MDServiceSPI(algorithm, new MDReference(clonedRef, algorithm));
         }
     }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/JOMLDSAPrivateKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/JOMLDSAPrivateKey.java
@@ -54,11 +54,12 @@ class JOMLDSAPrivateKey extends AsymmetricKeyImpl implements MLDSAPrivateKey, OS
     @Override
     public byte[] getEncoded()
     {
+        // FIPS 204: AlgorithmIdentifier parameters MUST be absent.
         if (seedOnly)
         {
-            return ASN1Encoder.asPrivateKeyInfo(spec, PrivateKeyOptions.SEED_ONLY);
+            return ASN1Encoder.asCanonicalPrivateKeyInfo(spec, PrivateKeyOptions.SEED_ONLY);
         }
-        return ASN1Encoder.asPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
+        return ASN1Encoder.asCanonicalPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
     }
 
     public byte[] getSeed()

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/JOMLDSAPublicKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/JOMLDSAPublicKey.java
@@ -40,8 +40,8 @@ class JOMLDSAPublicKey extends AsymmetricKeyImpl implements MLDSAPublicKey
     @Override
     public byte[] getEncoded()
     {
-        // ASN1
-        return ASN1Encoder.asSubjectPublicKeyInfo(spec);
+        // FIPS 204: AlgorithmIdentifier parameters MUST be absent.
+        return ASN1Encoder.asCanonicalSubjectPublicKeyInfo(spec);
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSAKeyPairGeneratorImpl.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mldsa/MLDSAKeyPairGeneratorImpl.java
@@ -14,8 +14,10 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.MLDSAParameterSpec;
 import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.PKEYKeySpec;
+import org.openssl.jostle.jcajce.util.SpecUtil;
 import org.openssl.jostle.rand.DefaultRandSource;
 import org.openssl.jostle.rand.RandSource;
+import org.openssl.jostle.util.Strings;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
@@ -94,18 +96,31 @@ public class MLDSAKeyPairGeneratorImpl extends KeyPairGenerator
     @Override
     public void initialize(AlgorithmParameterSpec params, SecureRandom rand) throws InvalidAlgorithmParameterException
     {
-        if (!(params instanceof MLDSAParameterSpec))
+        if (params == null)
         {
-            throw new InvalidAlgorithmParameterException("only MLDSAParameterSpec is supported");
+            throw new InvalidAlgorithmParameterException("parameter spec cannot be null");
         }
 
-        MLDSAParameterSpec spec = (MLDSAParameterSpec) params;
+        // Resolve the parameter-set name: use the name directly for our own
+        // MLDSAParameterSpec, otherwise reflect on getName() so a foreign spec
+        // (e.g. BouncyCastle's MLDSAParameterSpec) is accepted too.
+        String specName;
+        if (params instanceof MLDSAParameterSpec)
+        {
+            specName = ((MLDSAParameterSpec) params).getName();
+        }
+        else
+        {
+            String reflected = SpecUtil.getNameFrom(params);
+            specName = (reflected == null) ? null : Strings.toUpperCase(reflected);
+        }
 
-        OSSLKeyType newType = paramToTypeMap.get(spec.getName());
+        OSSLKeyType newType = (specName == null) ? null : paramToTypeMap.get(specName);
 
         if (newType == null)
         {
-            throw new InvalidAlgorithmParameterException("unknown algorithm: " + spec.getName());
+            throw new InvalidAlgorithmParameterException(
+                    "unknown algorithm: " + (specName != null ? specName : params.getClass().getName()));
         }
 
         if (keyType == OSSLKeyType.NONE)
@@ -131,7 +146,7 @@ public class MLDSAKeyPairGeneratorImpl extends KeyPairGenerator
         {
             throw new InvalidAlgorithmParameterException(
                     "supplied SecureRandom reports " + suppliedStrength
-                            + "-bit strength but " + spec.getName()
+                            + "-bit strength but " + specName
                             + " requires " + strengthBits);
         }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/JOMLKEMPrivateKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/JOMLKEMPrivateKey.java
@@ -53,11 +53,12 @@ class JOMLKEMPrivateKey extends AsymmetricKeyImpl implements MLKEMPrivateKey
     @Override
     public byte[] getEncoded()
     {
+        // FIPS 203: AlgorithmIdentifier parameters MUST be absent.
         if (seedOnly)
         {
-            return ASN1Encoder.asPrivateKeyInfo(spec, PrivateKeyOptions.SEED_ONLY);
+            return ASN1Encoder.asCanonicalPrivateKeyInfo(spec, PrivateKeyOptions.SEED_ONLY);
         }
-        return ASN1Encoder.asPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
+        return ASN1Encoder.asCanonicalPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
     }
 
     public byte[] getSeed()

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/JOMLKEMPublicKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/JOMLKEMPublicKey.java
@@ -40,8 +40,8 @@ class JOMLKEMPublicKey extends AsymmetricKeyImpl implements MLKEMPublicKey
     @Override
     public byte[] getEncoded()
     {
-        // ASN1
-        return ASN1Encoder.asSubjectPublicKeyInfo(spec);
+        // FIPS 203: AlgorithmIdentifier parameters MUST be absent.
+        return ASN1Encoder.asCanonicalSubjectPublicKeyInfo(spec);
     }
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyPairGenerator.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/mlkem/MLKEMKeyPairGenerator.java
@@ -14,8 +14,10 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.MLKEMParameterSpec;
 import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.PKEYKeySpec;
+import org.openssl.jostle.jcajce.util.SpecUtil;
 import org.openssl.jostle.rand.DefaultRandSource;
 import org.openssl.jostle.rand.RandSource;
+import org.openssl.jostle.util.Strings;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
@@ -89,18 +91,31 @@ public class MLKEMKeyPairGenerator extends KeyPairGenerator
     @Override
     public void initialize(AlgorithmParameterSpec params, SecureRandom random) throws InvalidAlgorithmParameterException
     {
-        if (!(params instanceof MLKEMParameterSpec))
+        if (params == null)
         {
-            throw new InvalidAlgorithmParameterException("only MLKEMParameterSpec is supported got " + params.getClass().getName());
+            throw new InvalidAlgorithmParameterException("parameter spec cannot be null");
         }
 
-        MLKEMParameterSpec spec = (MLKEMParameterSpec) params;
+        // Resolve the parameter-set name: use the name directly for our own
+        // MLKEMParameterSpec, otherwise reflect on getName() so a foreign spec
+        // (e.g. BouncyCastle's MLKEMParameterSpec) is accepted too.
+        String specName;
+        if (params instanceof MLKEMParameterSpec)
+        {
+            specName = ((MLKEMParameterSpec) params).getName();
+        }
+        else
+        {
+            String reflected = SpecUtil.getNameFrom(params);
+            specName = (reflected == null) ? null : Strings.toUpperCase(reflected);
+        }
 
-        OSSLKeyType newType = paramToTypeMap.get(spec.getName());
+        OSSLKeyType newType = (specName == null) ? null : paramToTypeMap.get(specName);
 
         if (newType == null)
         {
-            throw new InvalidAlgorithmParameterException("unknown algorithm: " + spec.getName());
+            throw new InvalidAlgorithmParameterException(
+                    "unknown algorithm: " + (specName != null ? specName : params.getClass().getName()));
         }
 
         if (keyType == OSSLKeyType.NONE)
@@ -128,7 +143,7 @@ public class MLKEMKeyPairGenerator extends KeyPairGenerator
         {
             throw new InvalidAlgorithmParameterException(
                     "supplied SecureRandom reports " + suppliedStrength
-                            + "-bit strength but " + spec.getName()
+                            + "-bit strength but " + specName
                             + " requires " + strengthBits);
         }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAKeyFactorySpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAKeyFactorySpi.java
@@ -16,6 +16,7 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.PKEYKeySpec;
 import org.openssl.jostle.util.asn1.ASN1Encoder;
+import org.openssl.jostle.util.asn1.KeyInfoCanonicalizer;
 
 import java.math.BigInteger;
 import java.security.Key;
@@ -37,7 +38,11 @@ public class RSAKeyFactorySpi extends KeyFactorySpi
     {
         if (keySpec instanceof X509EncodedKeySpec)
         {
-            byte[] encoded = ((X509EncodedKeySpec) keySpec).getEncoded();
+            // An id-RSASSA-PSS SPKI is a structurally-identical RSA key; rewrite
+            // it to rsaEncryption (as BC/SunRsaSign do) so it imports under RSA.
+            // A plain rsaEncryption key is returned unchanged.
+            byte[] encoded = KeyInfoCanonicalizer.rsaSubjectPublicKeyInfo(
+                    ((X509EncodedKeySpec) keySpec).getEncoded());
             PKEYKeySpec spec = ASN1Encoder.fromSubjectPublicKeyInfo(encoded, 0, encoded.length);
             requireRSA(spec);
             return new JORSAPublicKey(spec);
@@ -60,7 +65,10 @@ public class RSAKeyFactorySpi extends KeyFactorySpi
     {
         if (keySpec instanceof PKCS8EncodedKeySpec)
         {
-            byte[] encoded = ((PKCS8EncodedKeySpec) keySpec).getEncoded();
+            // See engineGeneratePublic: rewrite an id-RSASSA-PSS PrivateKeyInfo to
+            // rsaEncryption; a plain rsaEncryption key is returned unchanged.
+            byte[] encoded = KeyInfoCanonicalizer.rsaPrivateKeyInfo(
+                    ((PKCS8EncodedKeySpec) keySpec).getEncoded());
             PKEYKeySpec spec = ASN1Encoder.fromPrivateKeyInfo(encoded, 0, encoded.length);
             requireRSA(spec);
             return new JORSAPrivateKey(spec);

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAServiceNI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSAServiceNI.java
@@ -31,6 +31,9 @@ public interface RSAServiceNI extends DefaultServiceNI
     // Padding modes. MUST match RSA_PADDING_* in rsa.h.
     int PADDING_PKCS1 = 1;
     int PADDING_PSS = 2;
+    // Raw PKCS#1 v1.5 ("NoneWithRSA"): caller supplies the already-formed
+    // bytes (e.g. a DigestInfo); no digest is computed in the engine.
+    int PADDING_PKCS1_NONE = 3;
 
     // Component selectors. MUST match RSA_COMP_* in rsa.h.
     int COMP_MODULUS = 0;

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/rsa/RSASignatureSpi.java
@@ -132,4 +132,40 @@ public class RSASignatureSpi extends RSASignatureSpiBase
             super("SHA3-512");
         }
     }
+
+    /**
+     * Raw PKCS#1 v1.5 — "NoneWithRSA". The engine performs no hashing; the
+     * caller-supplied bytes (typically a pre-formed DigestInfo) are buffered
+     * and signed/verified with PKCS#1 v1.5 block-type-1 padding directly.
+     * Required by TLS 1.3's externally-hashed CertificateVerify path
+     * (BouncyCastle's {@code JcaTlsRSASigner.getRawSigner()}).
+     */
+    public static class None extends RSASignatureSpi
+    {
+        public None()
+        {
+            super("NONE");
+        }
+
+        @Override
+        protected void nativeInitSign(long ref, long keyRef, RandSource rnd)
+        {
+            rsaServiceNI.initSign(ref, keyRef,
+                    "NONE",
+                    RSAServiceNI.PADDING_PKCS1_NONE,
+                    null,
+                    0,
+                    rnd);
+        }
+
+        @Override
+        protected void nativeInitVerify(long ref, long keyRef)
+        {
+            rsaServiceNI.initVerify(ref, keyRef,
+                    "NONE",
+                    RSAServiceNI.PADDING_PKCS1_NONE,
+                    null,
+                    0);
+        }
+    }
 }

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/JOSLHDSAPrivateKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/JOSLHDSAPrivateKey.java
@@ -46,7 +46,8 @@ class JOSLHDSAPrivateKey extends AsymmetricKeyImpl implements SLHDSAPrivateKey, 
     @Override
     public byte[] getEncoded()
     {
-        return ASN1Encoder.asPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
+        // FIPS 205: AlgorithmIdentifier parameters MUST be absent.
+        return ASN1Encoder.asCanonicalPrivateKeyInfo(spec, PrivateKeyOptions.DEFAULT);
     }
 
     public byte[] getDirectEncoding()

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/JOSLHDSAPublicKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/JOSLHDSAPublicKey.java
@@ -40,8 +40,8 @@ class JOSLHDSAPublicKey extends AsymmetricKeyImpl implements SLHDSAPublicKey
     @Override
     public byte[] getEncoded()
     {
-        // ASN1
-        return ASN1Encoder.asSubjectPublicKeyInfo(spec);
+        // FIPS 205: AlgorithmIdentifier parameters MUST be absent.
+        return ASN1Encoder.asCanonicalSubjectPublicKeyInfo(spec);
     }
 
     public PKEYKeySpec getSpec()

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSAKeyPairGenerator.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/slhdsa/SLHDSAKeyPairGenerator.java
@@ -14,8 +14,10 @@ import org.openssl.jostle.jcajce.provider.NISelector;
 import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.PKEYKeySpec;
 import org.openssl.jostle.jcajce.spec.SLHDSAParameterSpec;
+import org.openssl.jostle.jcajce.util.SpecUtil;
 import org.openssl.jostle.rand.DefaultRandSource;
 import org.openssl.jostle.rand.RandSource;
+import org.openssl.jostle.util.Strings;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
@@ -99,18 +101,31 @@ public class SLHDSAKeyPairGenerator extends KeyPairGenerator
     @Override
     public void initialize(AlgorithmParameterSpec params, SecureRandom random) throws InvalidAlgorithmParameterException
     {
-        if (!(params instanceof SLHDSAParameterSpec))
+        if (params == null)
         {
-            throw new InvalidAlgorithmParameterException("only SLHDSAParameterSpec is supported");
+            throw new InvalidAlgorithmParameterException("parameter spec cannot be null");
         }
 
-        SLHDSAParameterSpec spec = (SLHDSAParameterSpec) params;
+        // Resolve the parameter-set name: use the name directly for our own
+        // SLHDSAParameterSpec, otherwise reflect on getName() so a foreign spec
+        // (e.g. BouncyCastle's SLHDSAParameterSpec) is accepted too.
+        String specName;
+        if (params instanceof SLHDSAParameterSpec)
+        {
+            specName = ((SLHDSAParameterSpec) params).getName();
+        }
+        else
+        {
+            String reflected = SpecUtil.getNameFrom(params);
+            specName = (reflected == null) ? null : Strings.toUpperCase(reflected);
+        }
 
-        OSSLKeyType newType = paramToTypeMap.get(spec.getName());
+        OSSLKeyType newType = (specName == null) ? null : paramToTypeMap.get(specName);
 
         if (newType == null)
         {
-            throw new InvalidAlgorithmParameterException("unknown algorithm: " + spec.getName());
+            throw new InvalidAlgorithmParameterException(
+                    "unknown algorithm: " + (specName != null ? specName : params.getClass().getName()));
         }
 
         if (forcedType == OSSLKeyType.NONE)
@@ -140,7 +155,7 @@ public class SLHDSAKeyPairGenerator extends KeyPairGenerator
         {
             throw new InvalidAlgorithmParameterException(
                     "supplied SecureRandom reports " + suppliedStrength
-                            + "-bit strength but " + spec.getName()
+                            + "-bit strength but " + specName
                             + " requires " + strengthBits);
         }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/spec/MLDSAParameterSpec.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/spec/MLDSAParameterSpec.java
@@ -28,7 +28,7 @@ public class MLDSAParameterSpec
     public static final MLDSAParameterSpec ml_dsa_87 = new MLDSAParameterSpec("ML-DSA-87", false);
 
 
-    private static Map parameters = new HashMap();
+    private static final Map<String, MLDSAParameterSpec> parameters = new HashMap<>();
 
     static
     {

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/spec/MLKEMParameterSpec.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/spec/MLKEMParameterSpec.java
@@ -10,6 +10,8 @@
 
 package org.openssl.jostle.jcajce.spec;
 
+import org.openssl.jostle.util.Strings;
+
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.*;
 
@@ -20,7 +22,7 @@ public class MLKEMParameterSpec implements AlgorithmParameterSpec
     public static final MLKEMParameterSpec ml_kem_768 = new MLKEMParameterSpec("ML-KEM-768", OSSLKeyType.ML_KEM_768);
     public static final MLKEMParameterSpec ml_kem_1024 = new MLKEMParameterSpec("ML-KEM-1024", OSSLKeyType.ML_KEM_1024);
 
-    private static final Map parameters = new HashMap();
+    private static final Map<String, MLKEMParameterSpec> parameters = new HashMap<>();
 
     private static final Set<MLKEMParameterSpec> parameterSpecs = Collections.unmodifiableSet(new HashSet<MLKEMParameterSpec>()
     {
@@ -45,15 +47,11 @@ public class MLKEMParameterSpec implements AlgorithmParameterSpec
         parameters.put("ml-kem-768", MLKEMParameterSpec.ml_kem_768);
         parameters.put("ml-kem-1024", MLKEMParameterSpec.ml_kem_1024);
 
-        parameters.put("kyber512", MLKEMParameterSpec.ml_kem_512);
-        parameters.put("kyber768", MLKEMParameterSpec.ml_kem_768);
-        parameters.put("kyber1024", MLKEMParameterSpec.ml_kem_1024);
-
-        parameters.put(OSSLKeyType.ML_KEM_512, ml_kem_512);
-        parameters.put(OSSLKeyType.ML_KEM_768, ml_kem_768);
-        parameters.put(OSSLKeyType.ML_KEM_1024, ml_kem_1024);
-
-
+        // Short aliases (no hyphens), matching the "MLKEM512" alias form used by
+        // OSSLKeyType. Looked up case-insensitively via fromName's toLowerCase.
+        parameters.put("mlkem512", MLKEMParameterSpec.ml_kem_512);
+        parameters.put("mlkem768", MLKEMParameterSpec.ml_kem_768);
+        parameters.put("mlkem1024", MLKEMParameterSpec.ml_kem_1024);
     }
 
     private final String name;
@@ -113,14 +111,17 @@ public class MLKEMParameterSpec implements AlgorithmParameterSpec
     {
         if (name == null)
         {
-            throw new IllegalArgumentException("name cannot be null");
+            throw new NullPointerException("name cannot be null");
         }
-        MLKEMParameterSpec spec = (MLKEMParameterSpec) parameters.get(name);
-        if (spec == null)
+
+        MLKEMParameterSpec parameterSpec = (MLKEMParameterSpec)parameters.get(Strings.toLowerCase(name));
+
+        if (parameterSpec == null)
         {
-            throw new IllegalArgumentException("Unknown MLKEM parameter spec: " + name);
+            throw new IllegalArgumentException("unknown parameter name: " + name);
         }
-        return spec;
+
+        return parameterSpec;
     }
 
     public static Set<MLKEMParameterSpec> getParameterSpecs()

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/spec/OSSLKeyType.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/spec/OSSLKeyType.java
@@ -12,6 +12,7 @@ package org.openssl.jostle.jcajce.spec;
 
 // ksType values must match macros in key_spec.h
 
+import org.openssl.jostle.util.asn1.oids.EdECObjectIdentifiers;
 import org.openssl.jostle.util.asn1.oids.NISTObjectIdentifiers;
 
 import java.util.HashMap;
@@ -51,8 +52,8 @@ public enum OSSLKeyType
     // XDH key agreement (RFC 8410). First alias is the OpenSSL EVP_PKEY
     // type name (what EVP_PKEY_get0_type_name returns), so decode-by-name
     // through PKEYKeySpec(long) maps to these.
-    X25519(27, "X25519", "1.3.101.110", "id-X25519"),
-    X448(28, "X448", "1.3.101.111", "id-X448");
+    X25519(27, "X25519", EdECObjectIdentifiers.id_X25519.getId(), "id-X25519"),
+    X448(28, "X448", EdECObjectIdentifiers.id_X448.getId(), "id-X448");
 
     private final String[] aliases;
     int ksType;

--- a/jostle/src/main/java/org/openssl/jostle/util/asn1/ASN1Encoder.java
+++ b/jostle/src/main/java/org/openssl/jostle/util/asn1/ASN1Encoder.java
@@ -60,6 +60,29 @@ public class ASN1Encoder
         }
     }
 
+    /**
+     * As {@link #asSubjectPublicKeyInfo(PKEYKeySpec)} but with the
+     * AlgorithmIdentifier {@code parameters} guaranteed absent — for FIPS
+     * 203/204/205 keys (ML-KEM, ML-DSA, SLH-DSA), where an explicit NULL is
+     * forbidden. Strips a stray NULL the underlying encoder may emit so the
+     * output is conformant regardless of OpenSSL version or provider install
+     * state. Mirrors the input-side {@link KeyInfoCanonicalizer} the PQC
+     * KeyFactories already apply. MUST NOT be used for RSA (rsaEncryption
+     * requires the NULL).
+     */
+    public static byte[] asCanonicalSubjectPublicKeyInfo(PKEYKeySpec spec)
+    {
+        return KeyInfoCanonicalizer.subjectPublicKeyInfo(asSubjectPublicKeyInfo(spec));
+    }
+
+    /**
+     * Private-key counterpart of {@link #asCanonicalSubjectPublicKeyInfo(PKEYKeySpec)}.
+     */
+    public static byte[] asCanonicalPrivateKeyInfo(PKEYKeySpec spec, PrivateKeyOptions option)
+    {
+        return KeyInfoCanonicalizer.privateKeyInfo(asPrivateKeyInfo(spec, option));
+    }
+
     public static PKEYKeySpec fromPrivateKeyInfo(byte[] data, int start, int len)
     {
         long ref = NISelector.Asn1NI.fromPrivateKeyInfo(data, start, len);

--- a/jostle/src/main/java/org/openssl/jostle/util/asn1/KeyInfoCanonicalizer.java
+++ b/jostle/src/main/java/org/openssl/jostle/util/asn1/KeyInfoCanonicalizer.java
@@ -100,6 +100,117 @@ public final class KeyInfoCanonicalizer
     }
 
     /**
+     * id-RSASSA-PSS OBJECT IDENTIFIER (1.2.840.113549.1.1.10) as a DER TLV.
+     * Differs from rsaEncryption (1.2.840.113549.1.1.1) only in the final byte.
+     */
+    private static final byte[] ID_RSASSA_PSS_OID = {
+            0x06, 0x09, 0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0x0D, 0x01, 0x01, 0x0A
+    };
+
+    /**
+     * Canonical rsaEncryption (1.2.840.113549.1.1.1) AlgorithmIdentifier:
+     * {@code SEQUENCE { OBJECT IDENTIFIER rsaEncryption, NULL }}. PKCS#1 requires
+     * the NULL parameters for rsaEncryption.
+     */
+    private static final byte[] RSA_ENCRYPTION_ALG_ID = {
+            0x30, 0x0D, 0x06, 0x09, 0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0x0D,
+            0x01, 0x01, 0x01, 0x05, 0x00
+    };
+
+    /**
+     * Rewrite an {@code id-RSASSA-PSS} SubjectPublicKeyInfo to {@code rsaEncryption}
+     * so OpenSSL decodes it as a plain RSA key. An RSASSA-PSS public key is
+     * structurally identical to an rsaEncryption one (the OID merely restricts the
+     * key to PSS); BC and SunRsaSign import both under "RSA". The whole
+     * AlgorithmIdentifier (OID and any RSASSA-PSS-params) is replaced with the
+     * canonical rsaEncryption identifier; the BIT STRING key bits are preserved.
+     * <p>
+     * Any input whose algorithm is not id-RSASSA-PSS is returned unchanged — in
+     * particular a genuine rsaEncryption key keeps its required NULL parameters
+     * (this is NOT the FIPS NULL-stripping path).
+     */
+    public static byte[] rsaSubjectPublicKeyInfo(byte[] spki)
+    {
+        try
+        {
+            int[] pos = {0};
+            int end = readSequenceHeader(spki, pos);        // SubjectPublicKeyInfo
+            int[] algPos = {pos[0]};
+            int algEnd = readSequenceHeader(spki, algPos);  // AlgorithmIdentifier
+
+            if (!isRsaPssOid(spki, algPos[0], algEnd))
+            {
+                return spki;
+            }
+
+            byte[] subjectPublicKey = Arrays.copyOfRange(spki, algEnd, end);
+            return derSequence(Arrays.concatenate(RSA_ENCRYPTION_ALG_ID, subjectPublicKey));
+        }
+        catch (RuntimeException e)
+        {
+            return spki;
+        }
+    }
+
+    /**
+     * Private-key counterpart of {@link #rsaSubjectPublicKeyInfo(byte[])}: rewrite
+     * an {@code id-RSASSA-PSS} PrivateKeyInfo to {@code rsaEncryption}. The version
+     * INTEGER and the privateKey OCTET STRING (plus any trailing fields) are
+     * preserved; only the privateKeyAlgorithm is replaced.
+     */
+    public static byte[] rsaPrivateKeyInfo(byte[] pki)
+    {
+        try
+        {
+            int[] pos = {0};
+            int end = readSequenceHeader(pki, pos);         // PrivateKeyInfo
+            int versionStart = pos[0];
+            int[] versionPos = {versionStart};
+            skipTlv(pki, versionPos);                       // version INTEGER
+            int algStart = versionPos[0];
+            int[] algPos = {algStart};
+            int algEnd = readSequenceHeader(pki, algPos);   // privateKeyAlgorithm
+
+            if (!isRsaPssOid(pki, algPos[0], algEnd))
+            {
+                return pki;
+            }
+
+            byte[] version = Arrays.copyOfRange(pki, versionStart, algStart);
+            byte[] rest = Arrays.copyOfRange(pki, algEnd, end);  // OCTET STRING + optional fields
+            return derSequence(Arrays.concatenate(version, RSA_ENCRYPTION_ALG_ID, rest));
+        }
+        catch (RuntimeException e)
+        {
+            return pki;
+        }
+    }
+
+    /**
+     * True if the AlgorithmIdentifier content spanning {@code [algContentStart, algEnd)}
+     * begins with the id-RSASSA-PSS OBJECT IDENTIFIER.
+     */
+    private static boolean isRsaPssOid(byte[] data, int algContentStart, int algEnd)
+    {
+        int[] pos = {algContentStart};
+        int oidStart = pos[0];
+        skipTlv(data, pos);                                 // algorithm OBJECT IDENTIFIER
+        int oidEnd = pos[0];
+        if (oidEnd > algEnd || oidEnd - oidStart != ID_RSASSA_PSS_OID.length)
+        {
+            return false;
+        }
+        for (int i = 0; i < ID_RSASSA_PSS_OID.length; i++)
+        {
+            if (data[oidStart + i] != ID_RSASSA_PSS_OID[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * If the AlgorithmIdentifier whose content spans {@code [algContentStart, algEnd)}
      * carries exactly an OBJECT IDENTIFIER followed by a NULL, return a rebuilt
      * AlgorithmIdentifier TLV ({@code SEQUENCE { OID }}) with the NULL removed;

--- a/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
+++ b/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
@@ -79,49 +79,46 @@ public class EdSignatureSpi extends SignatureSpi
 
         try
         {
-            if ((publicKey instanceof EdDSAPublicKey))
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their X.509 encoding, so a
+            // verify with a public key decoded by another provider works
+            // (JCA/TLS gap #5).
+            JOEdPublicKey key = EdKeyFactorySpi.importPublicKey(publicKey);
+
+            updateCalled = false;
+            lastKey = key;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                updateCalled = false;
-
-
-                JOEdPublicKey key = (JOEdPublicKey) publicKey;
-                lastKey = key;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), publicKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
-            throw new InvalidKeyException("expected only EdDSAPublicKey");
+
+            if (ref == null)
+            {
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
+            }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
         }
         finally
         {
@@ -140,56 +137,53 @@ public class EdSignatureSpi extends SignatureSpi
     {
         this.randSource = DefaultRandSource.replaceWith(this.randSource, secureRandom);
 
-        if (privateKey instanceof EdDSAPrivateKey)
+        try
         {
-            try
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their PKCS#8 encoding
+            // (JCA/TLS gap #5).
+            JOEdPrivateKey key = EdKeyFactorySpi.importPrivateKey(privateKey);
+            lastKey = key;
+            updateCalled = false;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                JOEdPrivateKey key = (JOEdPrivateKey) privateKey;
-                lastKey = key;
-                updateCalled = false;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), privateKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initSign(
-                        ref.getReference(),
-                        key.getSpec().getReference(), name, context, contextLen, randSource);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
-            finally
+
+            if (ref == null)
             {
-                Reference.reachabilityFence(this);
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
             }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initSign(
+                    ref.getReference(),
+                    key.getSpec().getReference(), name, context, contextLen, randSource);
         }
-        throw new InvalidKeyException("expected only EdDSAPrivateKey");
+        finally
+        {
+            Reference.reachabilityFence(this);
+        }
     }
 
     @Override

--- a/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/JOEdPrivateKey.java
+++ b/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/JOEdPrivateKey.java
@@ -45,7 +45,8 @@ public class JOEdPrivateKey extends AsymmetricKeyImpl implements EdDSAPrivateKey
     @Override
     public String getAlgorithm()
     {
-        return getType().getAlgorithmName();
+        // Canonical JCA name ("Ed25519"/"Ed448", mixed case) — matches SunEC/BC.
+        return getType().getTypeName();
     }
 
     @Override

--- a/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/JOEdPublicKey.java
+++ b/jostle/src/main/java15/org/openssl/jostle/jcajce/provider/ed/JOEdPublicKey.java
@@ -36,7 +36,10 @@ public class JOEdPublicKey extends AsymmetricKeyImpl implements EdDSAPublicKey, 
     @Override
     public String getAlgorithm()
     {
-        return getType().getAlgorithmName();
+        // Canonical JCA name ("Ed25519"/"Ed448", mixed case) — matches SunEC/BC
+        // so consumers that dispatch on getAlgorithm() (e.g. BC's TLS
+        // JcaTlsCertificate.getPubKeyEd25519) recognise the key.
+        return getType().getTypeName();
     }
 
     @Override

--- a/jostle/src/main/java25/org/openssl/jostle/jcajce/provider/md/MDServiceFFI.java
+++ b/jostle/src/main/java25/org/openssl/jostle/jcajce/provider/md/MDServiceFFI.java
@@ -26,6 +26,9 @@ public class MDServiceFFI implements MDServiceNI
     private static final MemorySegment allocateDigestFunc;
     private static final MethodHandle allocateDigestFuncHandle;
 
+    private static final MemorySegment copyDigestFunc;
+    private static final MethodHandle copyDigestFuncHandle;
+
     private static final MemorySegment updateByteFunc;
     private static final MethodHandle updateByteFuncHandle;
 
@@ -53,6 +56,15 @@ public class MDServiceFFI implements MDServiceNI
                         ValueLayout.ADDRESS, // *md_dtx
                         ValueLayout.ADDRESS, // const char *name
                         ValueLayout.JAVA_INT,// xof_len
+                        ValueLayout.ADDRESS // int *err
+                ), Linker.Option.critical(true)
+        );
+
+        copyDigestFunc = lookup.find("MD_Copy").orElseThrow();
+        copyDigestFuncHandle = linker.downcallHandle(copyDigestFunc,
+                FunctionDescriptor.of(
+                        ValueLayout.ADDRESS, // *md_ctx (the clone)
+                        ValueLayout.ADDRESS, // md_ctx *src
                         ValueLayout.ADDRESS // int *err
                 ), Linker.Option.critical(true)
         );
@@ -127,6 +139,24 @@ public class MDServiceFFI implements MDServiceNI
         catch (Throwable t)
         {
             L.log(Level.WARNING, "FFI MD_Allocate", t);
+            throw new RuntimeException(t.getMessage(), t);
+        }
+    }
+
+    @Override
+    public long ni_copyDigest(long ref, int[] err)
+    {
+        try
+        {
+            var errSeg = MemorySegment.ofArray(err);
+            var ctxSeg = (MemorySegment) copyDigestFuncHandle.invokeExact(
+                    MemorySegment.ofAddress(ref),
+                    errSeg);
+            return ctxSeg.address();
+        }
+        catch (Throwable t)
+        {
+            L.log(Level.WARNING, "FFI MD_Copy", t);
             throw new RuntimeException(t.getMessage(), t);
         }
     }

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECComponents.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECComponents.java
@@ -160,6 +160,54 @@ final class ECComponents
     }
 
     /**
+     * Canonicalise a caller-supplied curve name to one the loaded
+     * OpenSSL build accepts via {@code OSSL_PKEY_PARAM_GROUP_NAME}.
+     *
+     * <p>OpenSSL does not recognise every standard name for a curve:
+     * P-256 is registered under {@code prime256v1}/{@code P-256} but NOT
+     * the SECG {@code secp256r1} nor the X9.62 OID
+     * {@code 1.2.840.10045.3.1.7}, even though those are the names TLS
+     * (and SECG) callers use. This method maps any accepted alias of a
+     * curve to a name OpenSSL does recognise. Returns {@code null} if no
+     * form of the curve is supported by the loaded build.
+     */
+    static String toOpenSSLCurveName(String requested)
+    {
+        if (requested == null)
+        {
+            return null;
+        }
+        if (NISelector.ECServiceNI.curveSupported(requested))
+        {
+            return requested;
+        }
+        for (String[] family : CURVE_ALIASES.values())
+        {
+            boolean member = false;
+            for (String alias : family)
+            {
+                if (alias.equals(requested))
+                {
+                    member = true;
+                    break;
+                }
+            }
+            if (!member)
+            {
+                continue;
+            }
+            for (String candidate : family)
+            {
+                if (NISelector.ECServiceNI.curveSupported(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Compare two {@link ECParameterSpec} instances field-by-field.
      */
     private static boolean paramsEqual(ECParameterSpec a, ECParameterSpec b)
@@ -227,7 +275,7 @@ final class ECComponents
      * {@code switch}-with-fallthrough hazards a manual editor might
      * introduce when adding a new family.
      */
-    private static String[] aliasesFor(String curveName)
+    static String[] aliasesFor(String curveName)
     {
         String[] aliases = CURVE_ALIASES.get(curveName);
         return aliases != null ? aliases : new String[]{curveName};

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ec/ECDSASignatureSpi.java
@@ -361,4 +361,14 @@ public class ECDSASignatureSpi extends SignatureSpi
     {
         public SHA3_512() { super("SHA3-512"); }
     }
+
+    /**
+     * Raw ECDSA — "NoneWithECDSA". No hashing; the caller-supplied digest is
+     * buffered and signed/verified directly (DER-encoded ECDSA signature).
+     * Required by TLS 1.3's externally-hashed ECDSA CertificateVerify.
+     */
+    public static class None extends ECDSASignatureSpi
+    {
+        public None() { super("NONE"); }
+    }
 }

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/ed/EdSignatureSpi.java
@@ -79,49 +79,46 @@ public class EdSignatureSpi extends SignatureSpi
 
         try
         {
-            if ((publicKey instanceof EdDSAPublicKey))
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their X.509 encoding, so a
+            // verify with a public key decoded by another provider works
+            // (JCA/TLS gap #5).
+            JOEdPublicKey key = EdKeyFactorySpi.importPublicKey(publicKey);
+
+            updateCalled = false;
+            lastKey = key;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                updateCalled = false;
-
-
-                JOEdPublicKey key = (JOEdPublicKey) publicKey;
-                lastKey = key;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), publicKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
-            throw new InvalidKeyException("expected only EdDSAPublicKey");
+
+            if (ref == null)
+            {
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
+            }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initVerify(ref.getReference(), key.getSpec().getReference(), name, context, contextLen);
         }
         finally
         {
@@ -140,56 +137,53 @@ public class EdSignatureSpi extends SignatureSpi
     {
         this.randSource = DefaultRandSource.replaceWith(this.randSource, secureRandom);
 
-        if (privateKey instanceof EdDSAPrivateKey)
+        try
         {
-            try
+            // Accept Jostle-native keys directly and adopt foreign EdDSA
+            // keys (SunEC/BC) by re-decoding their PKCS#8 encoding
+            // (JCA/TLS gap #5).
+            JOEdPrivateKey key = EdKeyFactorySpi.importPrivateKey(privateKey);
+            lastKey = key;
+            updateCalled = false;
+
+            if (!matchForcedType(key.getType()))
             {
-
-                JOEdPrivateKey key = (JOEdPrivateKey) privateKey;
-                lastKey = key;
-                updateCalled = false;
-
-                if (!matchForcedType(key.getType()))
-                {
-                    throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
-                }
-
-                if (ref == null)
-                {
-                    ref = new EdDsaRef(edServiceNI.allocateSigner(), privateKey.getAlgorithm());
-                }
-
-                byte[] context = null;
-                int contextLen = 0;
-
-                if (algorithmParameterSpec instanceof ContextParameterSpec)
-                {
-                    switch (forcedType)
-                    {
-                        case Ed25519ctx:
-                        case Ed25519ph:
-                        case ED448ph:
-                            context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
-                            contextLen = context.length;
-                            break;
-                        default:
-                            throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
-                    }
-                }
-
-                String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
-
-                edServiceNI.initSign(
-                        ref.getReference(),
-                        key.getSpec().getReference(), name, context, contextLen, randSource);
-                return;
+                throw new InvalidKeyException("required " + forcedType.name() + " key type but got " + key.getSpec().getType());
             }
-            finally
+
+            if (ref == null)
             {
-                Reference.reachabilityFence(this);
+                ref = new EdDsaRef(edServiceNI.allocateSigner(), key.getAlgorithm());
             }
+
+            byte[] context = null;
+            int contextLen = 0;
+
+            if (algorithmParameterSpec instanceof ContextParameterSpec)
+            {
+                switch (forcedType)
+                {
+                    case Ed25519ctx:
+                    case Ed25519ph:
+                    case ED448ph:
+                        context = ((ContextParameterSpec) algorithmParameterSpec).getContext();
+                        contextLen = context.length;
+                        break;
+                    default:
+                        throw new InvalidKeyException(forcedType.name() + " does not accept a context parameter");
+                }
+            }
+
+            String name = forcedType != OSSLKeyType.NONE ? forcedType.name() : key.getType().getTypeName();
+
+            edServiceNI.initSign(
+                    ref.getReference(),
+                    key.getSpec().getReference(), name, context, contextLen, randSource);
         }
-        throw new InvalidKeyException("expected only EdDSAPrivateKey");
+        finally
+        {
+            Reference.reachabilityFence(this);
+        }
     }
 
     @Override

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/md/MDServiceSPI.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/md/MDServiceSPI.java
@@ -19,11 +19,12 @@ import java.lang.ref.Reference;
 import java.security.DigestException;
 import java.security.MessageDigestSpi;
 
-public class MDServiceSPI extends MessageDigestSpi
+public class MDServiceSPI extends MessageDigestSpi implements Cloneable
 {
     private static final MDServiceNI mdServiceNI = NISelector.MDServiceNI;
 
     private final MDReference ref;
+    private final String algorithm;
 
     public MDServiceSPI(String algorithm)
     {
@@ -31,6 +32,7 @@ public class MDServiceSPI extends MessageDigestSpi
         //
         // algoritm name must be something that OpenSSL can resolve
         //
+        this.algorithm = algorithm;
         this.ref = new MDReference(mdServiceNI.allocateDigest(algorithm, 0), algorithm);
     }
 
@@ -39,7 +41,20 @@ public class MDServiceSPI extends MessageDigestSpi
         //
         // algoritm name must be something that OpenSSL can resolve
         //
+        this.algorithm = algorithm;
         this.ref = new MDReference(mdServiceNI.allocateDigest(algorithm, xofLen), algorithm);
+    }
+
+    //
+    // Wrapping constructor for clone(): adopts an already-allocated native
+    // digest context (a copy produced by MDServiceNI.copyDigest). Distinct
+    // from the (String, int xofLen) constructor, which *allocates* a fresh
+    // context — this one takes ownership of an existing MDReference.
+    //
+    private MDServiceSPI(String algorithm, MDReference clonedRef)
+    {
+        this.algorithm = algorithm;
+        this.ref = clonedRef;
     }
 
 
@@ -119,6 +134,25 @@ public class MDServiceSPI extends MessageDigestSpi
         try
         {
             return mdServiceNI.getDigestOutputLen(ref.getReference());
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    //
+    // MessageDigest.clone() routes here (the JCA Delegate calls Object.clone()
+    // on the SPI when it is Cloneable). A shallow Object.clone() would share
+    // the single native EVP_MD_CTX between the original and the copy — a
+    // double-free and cross-talk hazard — so we deep-copy the native state via
+    // EVP_MD_CTX_copy_ex and hand the clone its own MDReference/Disposer.
+    //
+    @Override
+    public Object clone() throws CloneNotSupportedException
+    {
+        try
+        {
+            long clonedRef = mdServiceNI.copyDigest(ref.getReference());
+            return new MDServiceSPI(algorithm, new MDReference(clonedRef, algorithm));
         } finally {
             Reference.reachabilityFence(this);
         }

--- a/jostle/src/test/java/org/openssl/jostle/test/asn1/KeyInfoCanonicalizerTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/asn1/KeyInfoCanonicalizerTest.java
@@ -76,6 +76,42 @@ public class KeyInfoCanonicalizerTest
         run("ML-KEM-768");
     }
 
+    // Output side (gap #10): a FIPS 203/204/205 key's own getEncoded() must
+    // already carry absent AlgorithmIdentifier parameters, regardless of whether
+    // the provider is globally installed — running it through the canonicaliser
+    // must be a byte-for-byte no-op (a stray NULL would change it).
+
+    @Test
+    public void mldsa_outputCanonical() throws Exception
+    {
+        assertEncodedCanonical("ML-DSA-44");
+    }
+
+    @Test
+    public void slhdsa_outputCanonical() throws Exception
+    {
+        assertEncodedCanonical("SLH-DSA-SHA2-128F");
+    }
+
+    @Test
+    public void mlkem_outputCanonical() throws Exception
+    {
+        assertEncodedCanonical("ML-KEM-768");
+    }
+
+    private void assertEncodedCanonical(String alg) throws Exception
+    {
+        KeyPair kp = KeyPairGenerator.getInstance(alg, JostleProvider.PROVIDER_NAME).generateKeyPair();
+
+        byte[] spki = kp.getPublic().getEncoded();
+        Assertions.assertArrayEquals(spki, KeyInfoCanonicalizer.subjectPublicKeyInfo(spki),
+                alg + ": getEncoded() SPKI carries non-absent AlgorithmIdentifier parameters");
+
+        byte[] pkcs8 = kp.getPrivate().getEncoded();
+        Assertions.assertArrayEquals(pkcs8, KeyInfoCanonicalizer.privateKeyInfo(pkcs8),
+                alg + ": getEncoded() PKCS#8 carries non-absent privateKeyAlgorithm parameters");
+    }
+
     // -----------------------------------------------------------------
     // Direct synthetic unit tests of the canonicaliser's branches: an exact
     // NULL parameters element is stripped, and any other shape is returned

--- a/jostle/src/test/java/org/openssl/jostle/test/ec/ECDSANoneWithECDSASignatureTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/ec/ECDSANoneWithECDSASignatureTest.java
@@ -1,0 +1,306 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.ec;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.jcajce.provider.NISelector;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+/**
+ * Tests for the raw ECDSA {@code NoneWithECDSA} Signature (JCA/TLS gap #6).
+ * The engine performs no hashing — the caller supplies an already-computed
+ * digest and the engine produces/consumes a DER-encoded ECDSA signature.
+ * Required by TLS 1.3's externally-hashed ECDSA CertificateVerify.
+ *
+ * <p>ECDSA is randomised (OpenSSL does not use deterministic RFC&nbsp;6979
+ * nonces), so — unlike the RSA NoneWithRSA test — these assert
+ * verifiability and cross-provider agreement rather than byte-equality.
+ */
+public class ECDSANoneWithECDSASignatureTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static KeyPair joKeyPair;
+    private static PrivateKey bcPriv;
+    private static PublicKey bcPub;
+
+    private static SecureRandom seededRandom(String testName) throws Exception
+    {
+        long seed = RANDOM.nextLong();
+        System.out.println(testName + " seed=" + seed);
+        SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        sr.setSeed(seed);
+        return sr;
+    }
+
+    @BeforeAll
+    static void before() throws Exception
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+        Assumptions.assumeTrue(NISelector.ECServiceNI.curveSupported("P-256"),
+                "P-256 must be supported by the loaded OpenSSL build");
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(new ECGenParameterSpec("P-256"));
+        joKeyPair = kpg.generateKeyPair();
+
+        KeyFactory bcKf = KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(joKeyPair.getPrivate().getEncoded()));
+        bcPub = bcKf.generatePublic(new X509EncodedKeySpec(joKeyPair.getPublic().getEncoded()));
+    }
+
+    /**
+     * A NoneWithECDSA signature over {@code H = SHA-256(m)} must verify under
+     * the full {@code SHA256withECDSA} verifier on {@code m} (which computes
+     * {@code H} itself and then raw-verifies), and vice versa. This is the
+     * strongest functional check that the engine signs the supplied digest
+     * directly with no extra hashing — and it doesn't depend on determinism.
+     */
+    @Test
+    public void testNoneWithECDSA_interoperatesWithSHA256withECDSA() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithECDSA_interoperatesWithSHA256withECDSA");
+        byte[] msg = new byte[1 + sr.nextInt(512)];
+        sr.nextBytes(msg);
+        byte[] hash = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME).digest(msg);
+
+        // NoneWithECDSA(H) verifies under SHA256withECDSA(m).
+        Signature none = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        none.initSign(joKeyPair.getPrivate());
+        none.update(hash);
+        byte[] rawSig = none.sign();
+
+        Signature full = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        full.initVerify(joKeyPair.getPublic());
+        full.update(msg);
+        Assertions.assertTrue(full.verify(rawSig),
+                "SHA256withECDSA did not verify a NoneWithECDSA signature over SHA-256(m)");
+
+        // SHA256withECDSA(m) verifies under NoneWithECDSA(H).
+        Signature fullSigner = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        fullSigner.initSign(joKeyPair.getPrivate());
+        fullSigner.update(msg);
+        byte[] fullSig = fullSigner.sign();
+
+        Signature noneVerify = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        noneVerify.initVerify(joKeyPair.getPublic());
+        noneVerify.update(hash);
+        Assertions.assertTrue(noneVerify.verify(fullSig),
+                "NoneWithECDSA did not verify a SHA256withECDSA signature over the matching digest");
+
+        // Negative: a tampered digest must not verify.
+        hash[0] ^= 0x01;
+        Signature noneBad = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        noneBad.initVerify(joKeyPair.getPublic());
+        noneBad.update(hash);
+        Assertions.assertFalse(noneBad.verify(fullSig), "NoneWithECDSA verified a tampered digest");
+    }
+
+    /**
+     * Cross-provider agreement on a raw digest: each provider verifies the
+     * other's NoneWithECDSA signature. No byte-equality (ECDSA is randomised).
+     */
+    @Test
+    public void testNoneWithECDSA_agreesWithBouncyCastle() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithECDSA_agreesWithBouncyCastle");
+        for (int trial = 0; trial < 10; trial++)
+        {
+            byte[] digest = new byte[32]; // P-256 order is 256-bit
+            sr.nextBytes(digest);
+
+            Signature joSign = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            joSign.initSign(joKeyPair.getPrivate());
+            joSign.update(digest);
+            byte[] joSig = joSign.sign();
+
+            Signature bcVerify = Signature.getInstance("NoneWithECDSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcVerify.initVerify(bcPub);
+            bcVerify.update(digest);
+            Assertions.assertTrue(bcVerify.verify(joSig),
+                    "BC rejected a JSL NoneWithECDSA signature (trial " + trial + ")");
+
+            Signature bcSign = Signature.getInstance("NoneWithECDSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcSign.initSign(bcPriv);
+            bcSign.update(digest);
+            byte[] bcSig = bcSign.sign();
+
+            Signature joVerify = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            joVerify.initVerify(joKeyPair.getPublic());
+            joVerify.update(digest);
+            Assertions.assertTrue(joVerify.verify(bcSig),
+                    "JSL rejected a BC NoneWithECDSA signature (trial " + trial + ")");
+
+            // Negative: tampering the digest must break JSL verification.
+            byte[] tampered = org.openssl.jostle.util.Arrays.clone(digest);
+            tampered[sr.nextInt(tampered.length)] ^= 0x01;
+            Signature joVerifyBad = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            joVerifyBad.initVerify(joKeyPair.getPublic());
+            joVerifyBad.update(tampered);
+            Assertions.assertFalse(joVerifyBad.verify(joSig), "JSL verified a tampered digest");
+        }
+    }
+
+    /**
+     * The raw path is curve-agnostic (it just signs the supplied digest), but
+     * exercise P-384 and P-521 too — different field/order sizes and digest
+     * lengths — to confirm no fixed-length assumption crept in. Cross-verifies
+     * with BouncyCastle in both directions per curve.
+     */
+    @Test
+    public void testNoneWithECDSA_multiCurve_agreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithECDSA_multiCurve_agreesWithBC");
+        // (curve, digest length matching the curve's order size)
+        String[][] curves = {{"P-256", "32"}, {"P-384", "48"}, {"P-521", "66"}};
+
+        int tested = 0;
+        for (String[] row : curves)
+        {
+            String curve = row[0];
+            int digestLen = Integer.parseInt(row[1]);
+            if (!NISelector.ECServiceNI.curveSupported(curve))
+            {
+                continue;
+            }
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+            kpg.initialize(new ECGenParameterSpec(curve));
+            KeyPair kp = kpg.generateKeyPair();
+
+            KeyFactory bcKf = KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            PublicKey curveBcPub = bcKf.generatePublic(new X509EncodedKeySpec(kp.getPublic().getEncoded()));
+            PrivateKey curveBcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(kp.getPrivate().getEncoded()));
+
+            byte[] digest = new byte[digestLen];
+            sr.nextBytes(digest);
+
+            Signature joSign = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            joSign.initSign(kp.getPrivate());
+            joSign.update(digest);
+            byte[] joSig = joSign.sign();
+
+            Signature bcVerify = Signature.getInstance("NoneWithECDSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcVerify.initVerify(curveBcPub);
+            bcVerify.update(digest);
+            Assertions.assertTrue(bcVerify.verify(joSig), curve + ": BC rejected a JSL NoneWithECDSA signature");
+
+            Signature bcSign = Signature.getInstance("NoneWithECDSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcSign.initSign(curveBcPriv);
+            bcSign.update(digest);
+            byte[] bcSig = bcSign.sign();
+
+            Signature joVerify = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            joVerify.initVerify(kp.getPublic());
+            joVerify.update(digest);
+            Assertions.assertTrue(joVerify.verify(bcSig), curve + ": JSL rejected a BC NoneWithECDSA signature");
+
+            tested++;
+        }
+        Assertions.assertTrue(tested > 0, "no EC curves were testable against this OpenSSL build");
+    }
+
+    /**
+     * Buffering must be chunking-invariant: a one-shot update and a
+     * byte-by-byte update of the same digest each produce a signature that
+     * verifies. (The two signatures differ — ECDSA is randomised — so we
+     * assert verifiability, not equality.)
+     */
+    @Test
+    public void testNoneWithECDSA_chunkingInvariant() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithECDSA_chunkingInvariant");
+        byte[] digest = new byte[32];
+        sr.nextBytes(digest);
+
+        Signature oneShot = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        oneShot.initSign(joKeyPair.getPrivate());
+        oneShot.update(digest);
+        byte[] sigOneShot = oneShot.sign();
+
+        Signature byteWise = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        byteWise.initSign(joKeyPair.getPrivate());
+        for (byte b : digest)
+        {
+            byteWise.update(b);
+        }
+        byte[] sigByteWise = byteWise.sign();
+
+        for (byte[] sig : new byte[][]{sigOneShot, sigByteWise})
+        {
+            Signature v = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+            v.initVerify(joKeyPair.getPublic());
+            v.update(digest);
+            Assertions.assertTrue(v.verify(sig), "a chunking variant produced an unverifiable signature");
+        }
+    }
+
+    /**
+     * Reuse after a terminal op: the same instance signs two distinct digests,
+     * each verifying (proves the native buffer is cleared on re-init).
+     */
+    @Test
+    public void testNoneWithECDSA_reuseAfterSign() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithECDSA_reuseAfterSign");
+        byte[] d1 = new byte[32];
+        byte[] d2 = new byte[32];
+        sr.nextBytes(d1);
+        sr.nextBytes(d2);
+
+        Signature signer = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        signer.initSign(joKeyPair.getPrivate());
+        signer.update(d1);
+        byte[] sig1 = signer.sign();
+        signer.update(d2);
+        byte[] sig2 = signer.sign();
+
+        Signature v = Signature.getInstance("NoneWithECDSA", JostleProvider.PROVIDER_NAME);
+        v.initVerify(joKeyPair.getPublic());
+        v.update(d1);
+        Assertions.assertTrue(v.verify(sig1), "first reuse signature did not verify");
+
+        v.initVerify(joKeyPair.getPublic());
+        v.update(d2);
+        Assertions.assertTrue(v.verify(sig2), "second reuse signature did not verify");
+
+        // Cross-check: sig1 must NOT verify against d2 (guards a stale buffer
+        // that signed the wrong digest).
+        v.initVerify(joKeyPair.getPublic());
+        v.update(d2);
+        Assertions.assertFalse(v.verify(sig1), "sig over d1 wrongly verified against d2");
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/ec/ECOpsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/ec/ECOpsTest.java
@@ -1272,4 +1272,79 @@ public class ECOpsTest
             specNI.dispose(keyRef);
         }
     }
+
+
+    // -----------------------------------------------------------------
+    // Raw ECDSA (NoneWithECDSA, digest name "NONE") — ec_raw_init / sign / verify
+    // -----------------------------------------------------------------
+
+    @Test
+    public void ec_noneRawInitSign_opensslError()
+    {
+        Assumptions.assumeTrue(ops.opsTestAvailable());
+        long sigRef = ec.allocateSigner();
+        long keyRef = ec.generateKeyPair("P-256", TestUtil.RNDSrc);
+        try
+        {
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/ec.c:494
+            ops.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_11);
+            int code = ec.ni_initSign(sigRef, keyRef, "NONE", TestUtil.RNDSrc);
+            Assertions.assertEquals(errorAt(3100), code);
+        }
+        finally
+        {
+            ops.resetFlags();
+            ec.disposeSigner(sigRef);
+            specNI.dispose(keyRef);
+        }
+    }
+
+    @Test
+    public void ec_noneRawSign_opensslError()
+    {
+        Assumptions.assumeTrue(ops.opsTestAvailable());
+        long sigRef = ec.allocateSigner();
+        long keyRef = ec.generateKeyPair("P-256", TestUtil.RNDSrc);
+        try
+        {
+            ec.initSign(sigRef, keyRef, "NONE", TestUtil.RNDSrc);
+            ec.ni_update(sigRef, new byte[32], 0, 32);
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/ec.c:721
+            ops.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_12);
+            int code = ec.ni_sign(sigRef, null, 0, TestUtil.RNDSrc);
+            Assertions.assertEquals(errorAt(3101), code);
+        }
+        finally
+        {
+            ops.resetFlags();
+            ec.disposeSigner(sigRef);
+            specNI.dispose(keyRef);
+        }
+    }
+
+    @Test
+    public void ec_noneRawVerify_opensslError()
+    {
+        Assumptions.assumeTrue(ops.opsTestAvailable());
+        long sigRef = ec.allocateSigner();
+        long keyRef = ec.generateKeyPair("P-256", TestUtil.RNDSrc);
+        try
+        {
+            ec.initVerify(sigRef, keyRef, "NONE");
+            ec.ni_update(sigRef, new byte[32], 0, 32);
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/ec.c:811
+            ops.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_11);
+            int code = ec.ni_verify(sigRef, new byte[72], 72, TestUtil.RNDSrc);
+            Assertions.assertEquals(errorAt(3102), code);
+        }
+        finally
+        {
+            ops.resetFlags();
+            ec.disposeSigner(sigRef);
+            specNI.dispose(keyRef);
+        }
+    }
 }

--- a/jostle/src/test/java/org/openssl/jostle/test/ec/ECTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/ec/ECTest.java
@@ -20,6 +20,7 @@ import org.openssl.jostle.jcajce.provider.JostleProvider;
 import org.openssl.jostle.jcajce.provider.NISelector;
 
 import java.math.BigInteger;
+import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.KeyFactory;
@@ -33,9 +34,11 @@ import java.security.Signature;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECFieldFp;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
@@ -255,6 +258,115 @@ public class ECTest
             Assertions.assertTrue(
                     expected.getMessage().contains("ECGenParameterSpec"),
                     "expected ECGenParameterSpec in message, got: " + expected.getMessage());
+        }
+    }
+
+
+    // -----------------------------------------------------------------
+    // Curve-name aliasing: names OpenSSL doesn't accept directly must
+    // still resolve via canonicalisation (TLS / SECG callers use these)
+    // -----------------------------------------------------------------
+
+    /**
+     * OpenSSL registers P-256 only under {@code prime256v1}/{@code P-256}
+     * — NOT the SECG {@code secp256r1} nor the X9.62 OID. TLS
+     * ({@code NamedGroup.getCurveName(secp256r1)}) and SECG callers use
+     * {@code secp256r1}, so the provider must canonicalise it. Both forms
+     * must produce a working P-256 key (256-bit field).
+     */
+    @Test
+    public void testKeyPairGenerator_ecGenParameterSpec_secp256r1Alias() throws Exception
+    {
+        Assumptions.assumeTrue(NISelector.ECServiceNI.curveSupported("P-256"));
+        for (String name : new String[]{"secp256r1", "1.2.840.10045.3.1.7"})
+        {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+            kpg.initialize(new ECGenParameterSpec(name));
+            ECPublicKey pub = (ECPublicKey) kpg.generateKeyPair().getPublic();
+            Assertions.assertEquals(256, pub.getParams().getCurve().getField().getFieldSize(),
+                    name + " did not resolve to P-256");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Explicit-parameters ECParameterSpec acceptance
+    // -----------------------------------------------------------------
+
+    /**
+     * The generator accepts an explicit {@link ECParameterSpec} (standard
+     * JCA), reverse-resolving the supplied domain parameters to a named
+     * curve OpenSSL recognises. Drive it with the parameters of a real
+     * P-256 key and prove the resulting key is a usable P-256 key via a
+     * sign/verify round-trip (with a tampered-message negative check).
+     */
+    @Test
+    public void testKeyPairGenerator_explicitECParameterSpec_P256() throws Exception
+    {
+        Assumptions.assumeTrue(NISelector.ECServiceNI.curveSupported("P-256"));
+        SecureRandom sr = seededRandom("testKeyPairGenerator_explicitECParameterSpec_P256");
+
+        // Source a genuine P-256 ECParameterSpec from a named-curve key.
+        KeyPairGenerator seed = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        seed.initialize(new ECGenParameterSpec("P-256"));
+        ECParameterSpec p256 = ((ECPublicKey) seed.generateKeyPair().getPublic()).getParams();
+
+        // Now generate using the explicit-parameters surface.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(p256);
+        KeyPair kp = kpg.generateKeyPair();
+        Assertions.assertEquals(256,
+                ((ECPublicKey) kp.getPublic()).getParams().getCurve().getField().getFieldSize(),
+                "explicit P-256 parameters did not resolve to a 256-bit curve");
+
+        Signature signer = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        signer.initSign(kp.getPrivate());
+        byte[] msg = new byte[16 + sr.nextInt(256)];
+        sr.nextBytes(msg);
+        signer.update(msg);
+        byte[] sig = signer.sign();
+
+        Signature verifier = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        verifier.initVerify(kp.getPublic());
+        verifier.update(msg);
+        Assertions.assertTrue(verifier.verify(sig),
+                "key from explicit ECParameterSpec produced an unverifiable signature");
+
+        msg[0] ^= 1;
+        Signature tampered = Signature.getInstance("SHA256withECDSA", JostleProvider.PROVIDER_NAME);
+        tampered.initVerify(kp.getPublic());
+        tampered.update(msg);
+        Assertions.assertFalse(tampered.verify(sig),
+                "verification passed on a tampered message");
+    }
+
+    /**
+     * An explicit {@link ECParameterSpec} that matches no named curve
+     * OpenSSL recognises must be rejected with
+     * {@link InvalidAlgorithmParameterException} — key generation here is
+     * named-curve only.
+     */
+    @Test
+    public void testKeyPairGenerator_explicitECParameterSpec_unknownCurveRejected() throws Exception
+    {
+        // A small, made-up prime-field curve that matches no standard curve.
+        EllipticCurve curve = new EllipticCurve(
+                new ECFieldFp(BigInteger.valueOf(23)),
+                BigInteger.valueOf(1), BigInteger.valueOf(1));
+        ECParameterSpec bogus = new ECParameterSpec(
+                curve, new ECPoint(BigInteger.valueOf(3), BigInteger.valueOf(10)),
+                BigInteger.valueOf(7), 1);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        try
+        {
+            kpg.initialize(bogus);
+            Assertions.fail("expected rejection of an unknown explicit EC curve");
+        }
+        catch (InvalidAlgorithmParameterException expected)
+        {
+            Assertions.assertTrue(
+                    expected.getMessage().contains("do not match any named curve"),
+                    "unexpected message: " + expected.getMessage());
         }
     }
 
@@ -535,6 +647,62 @@ public class ECTest
         KeyFactory kf = KeyFactory.getInstance("1.2.840.10045.2.1",
                 JostleProvider.PROVIDER_NAME);
         Assertions.assertNotNull(kf);
+    }
+
+
+    // -----------------------------------------------------------------
+    // AlgorithmParameters("EC") — required by BC's TLS JceTlsECDomain
+    // -----------------------------------------------------------------
+
+    /**
+     * {@code AlgorithmParameters.getInstance("EC", "JSL")} must resolve
+     * and yield a usable {@link ECParameterSpec} for a named curve. This
+     * is the call BouncyCastle's {@code JceTlsECDomain} makes (via
+     * {@code helper.createAlgorithmParameters("EC")}) to obtain NIST-curve
+     * domain parameters before a TLS group can be negotiated.
+     */
+    @Test
+    public void testAlgorithmParameters_EC_resolvesNamedCurve() throws Exception
+    {
+        AlgorithmParameters ap = AlgorithmParameters.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        ap.init(new ECGenParameterSpec("secp256r1"));
+        ECParameterSpec spec = ap.getParameterSpec(ECParameterSpec.class);
+        Assertions.assertEquals(256, spec.getCurve().getField().getFieldSize(),
+                "AlgorithmParameters(\"EC\") did not yield P-256 parameters");
+    }
+
+    /**
+     * Resolvable by the id-ecPublicKey OID too — callers that key off the
+     * OID (e.g. ASN.1 decoders) must reach the same implementation.
+     */
+    @Test
+    public void testAlgorithmParameters_EC_resolvesByOID() throws Exception
+    {
+        AlgorithmParameters ap = AlgorithmParameters.getInstance("1.2.840.10045.2.1",
+                JostleProvider.PROVIDER_NAME);
+        ap.init(new ECGenParameterSpec("P-384"));
+        ECParameterSpec spec = ap.getParameterSpec(ECParameterSpec.class);
+        Assertions.assertEquals(384, spec.getCurve().getField().getFieldSize());
+    }
+
+    /**
+     * Encode → decode round-trip through the JSL AlgorithmParameters must
+     * be byte-stable, proving the delegate's ASN.1 codec is wired through.
+     */
+    @Test
+    public void testAlgorithmParameters_EC_encodeDecodeRoundTrip() throws Exception
+    {
+        AlgorithmParameters ap = AlgorithmParameters.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        ap.init(new ECGenParameterSpec("P-256"));
+        byte[] encoded = ap.getEncoded();
+        Assertions.assertNotNull(encoded);
+
+        AlgorithmParameters ap2 = AlgorithmParameters.getInstance("EC", JostleProvider.PROVIDER_NAME);
+        ap2.init(encoded);
+        ECParameterSpec spec = ap2.getParameterSpec(ECParameterSpec.class);
+        Assertions.assertEquals(256, spec.getCurve().getField().getFieldSize());
+        Assertions.assertArrayEquals(encoded, ap2.getEncoded(),
+                "EC AlgorithmParameters encode/decode round-trip changed bytes");
     }
 
 

--- a/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
@@ -254,7 +254,10 @@ public class EdDSATest
         }
         catch (InvalidKeyException e)
         {
-            Assertions.assertEquals("expected only EdDSAPublicKey", e.getMessage());
+            // The SPI now tries to adopt foreign keys by re-decoding their
+            // X.509 encoding (gap #5). This fake key's encoding isn't valid
+            // SubjectPublicKeyInfo, so import fails — still InvalidKeyException.
+            Assertions.assertEquals("unable to import EdDSA public key from its encoding", e.getMessage());
         }
     }
 
@@ -290,7 +293,10 @@ public class EdDSATest
         }
         catch (InvalidKeyException e)
         {
-            Assertions.assertEquals("expected only EdDSAPrivateKey", e.getMessage());
+            // The SPI now tries to adopt foreign keys by re-decoding their
+            // PKCS#8 encoding (gap #5). This fake key's encoding isn't valid
+            // PrivateKeyInfo, so import fails — still InvalidKeyException.
+            Assertions.assertEquals("unable to import EdDSA private key from its encoding", e.getMessage());
         }
     }
 
@@ -1685,6 +1691,103 @@ public class EdDSATest
             specNI.dispose(keyRef);
             specNI.dispose(roundTripRef);
         }
+    }
+
+
+    // -----------------------------------------------------------------
+    // Cross-provider key interop (JCA/TLS gap #5)
+    //
+    // JSL's Ed Signature must accept EdDSA keys decoded by a *different*
+    // provider — the case BouncyCastle's TLS layer hits when a peer
+    // certificate's public key was decoded elsewhere. Before the fix the
+    // SPI rejected any non-Jostle key with "expected only EdDSAPublicKey".
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testForeignKeyInterop_BC_Ed25519() throws Exception
+    {
+        runForeignKeyInterop("Ed25519");
+    }
+
+    @Test
+    public void testForeignKeyInterop_BC_Ed448() throws Exception
+    {
+        runForeignKeyInterop("Ed448");
+    }
+
+    private void runForeignKeyInterop(String alg) throws Exception
+    {
+        SecureRandom sr = seededRandom("foreignKeyInterop_" + alg);
+
+        // Foreign keypair — generated and owned by BouncyCastle.
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance(alg, BouncyCastleProvider.PROVIDER_NAME);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+
+        byte[] msg = new byte[16 + sr.nextInt(256)];
+        sr.nextBytes(msg);
+
+        // 1) Sign with BC, verify with JSL using BC's (foreign) public key.
+        Signature bcSigner = Signature.getInstance(alg, BouncyCastleProvider.PROVIDER_NAME);
+        bcSigner.initSign(bcKp.getPrivate());
+        bcSigner.update(msg);
+        byte[] bcSig = bcSigner.sign();
+
+        Signature joVerifier = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joVerifier.initVerify(bcKp.getPublic());
+        joVerifier.update(msg);
+        Assertions.assertTrue(joVerifier.verify(bcSig),
+                alg + ": JSL failed to verify a BC signature using BC's public key");
+
+        // Negative: a tampered message must not verify (guards against a
+        // stub that accepts anything once the foreign key is adopted).
+        byte[] tampered = msg.clone();
+        tampered[0] ^= 1;
+        Signature joVerifier2 = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joVerifier2.initVerify(bcKp.getPublic());
+        joVerifier2.update(tampered);
+        Assertions.assertFalse(joVerifier2.verify(bcSig),
+                alg + ": JSL verified a tampered message");
+
+        // 2) Sign with JSL using BC's (foreign) private key, verify with BC.
+        Signature joSigner = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joSigner.initSign(bcKp.getPrivate());
+        joSigner.update(msg);
+        byte[] joSig = joSigner.sign();
+
+        Signature bcVerifier = Signature.getInstance(alg, BouncyCastleProvider.PROVIDER_NAME);
+        bcVerifier.initVerify(bcKp.getPublic());
+        bcVerifier.update(msg);
+        Assertions.assertTrue(bcVerifier.verify(joSig),
+                alg + ": BC failed to verify a JSL signature made with BC's private key");
+
+        // EdDSA (RFC 8032) is deterministic — same key + message must yield
+        // byte-identical signatures regardless of which provider produced them.
+        Assertions.assertArrayEquals(bcSig, joSig,
+                alg + ": deterministic EdDSA signatures disagree between BC and JSL");
+    }
+
+    /**
+     * {@code KeyFactory.translateKey} on the JSL Ed factory must adopt a
+     * foreign EdDSA key, returning a Jostle-native key with the same
+     * encoding.
+     */
+    @Test
+    public void testKeyFactory_translateForeignEdKey_BC() throws Exception
+    {
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("Ed25519", BouncyCastleProvider.PROVIDER_NAME);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+
+        KeyFactory joKf = KeyFactory.getInstance("Ed25519", JostleProvider.PROVIDER_NAME);
+
+        Key joPub = joKf.translateKey(bcKp.getPublic());
+        Assertions.assertTrue(joPub instanceof org.openssl.jostle.jcajce.interfaces.EdDSAPublicKey,
+                "translateKey should yield a Jostle EdDSA public key");
+        Assertions.assertArrayEquals(bcKp.getPublic().getEncoded(), joPub.getEncoded(),
+                "translateKey must preserve the X.509 encoding");
+
+        Key joPriv = joKf.translateKey(bcKp.getPrivate());
+        Assertions.assertTrue(joPriv instanceof org.openssl.jostle.jcajce.interfaces.EdDSAPrivateKey,
+                "translateKey should yield a Jostle EdDSA private key");
     }
 
 

--- a/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
@@ -1792,6 +1792,27 @@ public class EdDSATest
     }
 
 
+    /**
+     * {@code getAlgorithm()} on JSL Ed keys must return the canonical mixed-case
+     * JCA name ("Ed25519"/"Ed448") — matching SunEC/BC — not the upper-case
+     * "ED25519"/"ED448" (JCA/TLS gap #9). Consumers like BC's TLS
+     * {@code JcaTlsCertificate.getPubKeyEd25519} dispatch on this exact string.
+     */
+    @Test
+    public void testEdKey_getAlgorithm_isCanonicalMixedCase() throws Exception
+    {
+        for (String alg : new String[]{"Ed25519", "Ed448"})
+        {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(alg, JostleProvider.PROVIDER_NAME);
+            KeyPair kp = kpg.generateKeyPair();
+            Assertions.assertEquals(alg, kp.getPublic().getAlgorithm(),
+                    alg + ": public getAlgorithm() must be canonical mixed-case");
+            Assertions.assertEquals(alg, kp.getPrivate().getAlgorithm(),
+                    alg + ": private getAlgorithm() must be canonical mixed-case");
+        }
+    }
+
+
     public static class TestAlgorithmParameterSpec implements AlgorithmParameterSpec
     {
         private final byte[] ctx;

--- a/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/eddsa/EdDSATest.java
@@ -35,6 +35,7 @@ import org.openssl.jostle.jcajce.spec.OSSLKeyType;
 import org.openssl.jostle.jcajce.spec.SpecNI;
 import org.openssl.jostle.test.TestUtil;
 import org.openssl.jostle.test.crypto.TestNISelector;
+import org.openssl.jostle.util.Arrays;
 import org.openssl.jostle.util.Pack;
 import org.openssl.jostle.util.Strings;
 import org.openssl.jostle.util.encoders.Hex;
@@ -1740,7 +1741,7 @@ public class EdDSATest
 
         // Negative: a tampered message must not verify (guards against a
         // stub that accepts anything once the foreign key is adopted).
-        byte[] tampered = msg.clone();
+        byte[] tampered = Arrays.clone(msg);
         tampered[0] ^= 1;
         Signature joVerifier2 = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
         joVerifier2.initVerify(bcKp.getPublic());

--- a/jostle/src/test/java/org/openssl/jostle/test/md/MDOpsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/md/MDOpsTest.java
@@ -239,4 +239,42 @@ public class MDOpsTest
         }
     }
 
+    @Test
+    public void copyDigest_failCreate() throws Exception {
+        Assumptions.assumeTrue(operationsTestNI.opsTestAvailable(),"OPS Test support not compiled in");
+        long ref = mdNI.allocateDigest("SHA256", 0);
+        try {
+            // Exercises interface/util/md.c:101
+            operationsTestNI.setFlag(OperationsTestNI.OpsTestFlag.OPS_FAILED_CREATE_2);
+            mdNI.copyDigest(ref);
+            Assertions.fail("Expected operation to fail but did not");
+        } catch (IllegalStateException e) {
+            Assertions.assertEquals("md create failed", e.getMessage());
+        } finally {
+            if (ref > 0) {
+                mdNI.dispose(ref);
+            }
+            operationsTestNI.resetFlags();
+        }
+    }
+
+    @Test
+    public void copyDigest_copyFailed() throws Exception {
+        Assumptions.assumeTrue(operationsTestNI.opsTestAvailable(),"OPS Test support not compiled in");
+        long ref = mdNI.allocateDigest("SHA256", 0);
+        try {
+            // Exercises interface/util/md.c:108
+            operationsTestNI.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_11);
+            mdNI.copyDigest(ref);
+            Assertions.fail("Expected operation to fail but did not");
+        } catch (IllegalStateException e) {
+            Assertions.assertEquals("md copy failed", e.getMessage());
+        } finally {
+            if (ref > 0) {
+                mdNI.dispose(ref);
+            }
+            operationsTestNI.resetFlags();
+        }
+    }
+
 }

--- a/jostle/src/test/java/org/openssl/jostle/test/md/MDTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/md/MDTest.java
@@ -403,25 +403,105 @@ public class MDTest
 
 
     //
-    // MDServiceSPI does not override engineClone, so MessageDigest.clone()
-    // should propagate the default CloneNotSupportedException. Pin this so
-    // a future "implement clone via EVP_MD_CTX_dup" change is intentional.
+    // MessageDigest.clone() snapshots the running digest via EVP_MD_CTX_copy_ex
+    // (gap #3 — required by TLS, which clones the transcript hash). The clone
+    // must carry the absorbed-so-far state AND be fully independent of the
+    // original: feeding different bytes to each after the split must produce
+    // exactly the digests of the respective full inputs.
     //
     @Test
-    public void testClone_notSupported() throws Exception
+    public void testClone_snapshotAndIndependence() throws Exception
     {
-        MessageDigest md = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME);
-        md.update("Hello".getBytes());
+        SecureRandom sr = seededRandom("testClone_snapshotAndIndependence");
+        byte[] prefix = new byte[16 + sr.nextInt(64)];
+        sr.nextBytes(prefix);
+        byte[] suffixA = new byte[16 + sr.nextInt(64)];
+        sr.nextBytes(suffixA);
+        byte[] suffixB = new byte[16 + sr.nextInt(64)];
+        sr.nextBytes(suffixB);
+        // Force the two branches to differ so the independence check is meaningful.
+        suffixB[0] ^= 0x01;
 
-        try
-        {
-            md.clone();
-            Assertions.fail("expected CloneNotSupportedException");
-        }
-        catch (CloneNotSupportedException e)
-        {
-            // expected
-        }
+        MessageDigest md = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME);
+        md.update(prefix);
+
+        MessageDigest copy = (MessageDigest) md.clone();
+
+        md.update(suffixA);
+        copy.update(suffixB);
+
+        byte[] origOut = md.digest();
+        byte[] copyOut = copy.digest();
+
+        MessageDigest ref = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME);
+        ref.update(prefix);
+        ref.update(suffixA);
+        Assertions.assertArrayEquals(ref.digest(), origOut,
+                "original digest changed by the clone (cross-talk)");
+
+        ref.update(prefix);
+        ref.update(suffixB);
+        Assertions.assertArrayEquals(ref.digest(), copyOut,
+                "clone did not carry the pre-split state");
+
+        Assertions.assertFalse(Arrays.areEqual(origOut, copyOut),
+                "distinct post-split inputs produced identical digests");
+    }
+
+    //
+    // A clone taken mid-stream, then completed, must agree with BouncyCastle's
+    // one-shot digest of the full input — cross-implementation confirmation
+    // that the snapshot is the genuine intermediate state, not a reset.
+    //
+    @Test
+    public void testClone_midStream_matchesBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("testClone_midStream_matchesBC");
+        byte[] prefix = new byte[16 + sr.nextInt(128)];
+        sr.nextBytes(prefix);
+        byte[] suffix = new byte[16 + sr.nextInt(128)];
+        sr.nextBytes(suffix);
+
+        MessageDigest md = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME);
+        md.update(prefix);
+        MessageDigest copy = (MessageDigest) md.clone();
+        copy.update(suffix);
+        byte[] joClone = copy.digest();
+
+        MessageDigest bc = MessageDigest.getInstance("SHA-256", BouncyCastleProvider.PROVIDER_NAME);
+        bc.update(prefix);
+        bc.update(suffix);
+        Assertions.assertArrayEquals(bc.digest(), joClone,
+                "cloned-then-completed digest disagrees with BouncyCastle");
+    }
+
+    //
+    // Cloning must work for XOF-backed digests too (SHAKE256-512), where the
+    // native context carries an xof flag and a fixed squeeze length that the
+    // copy must preserve.
+    //
+    @Test
+    public void testClone_xof_SHAKE256_512() throws Exception
+    {
+        SecureRandom sr = seededRandom("testClone_xof_SHAKE256_512");
+        byte[] prefix = new byte[16 + sr.nextInt(64)];
+        sr.nextBytes(prefix);
+        byte[] suffix = new byte[16 + sr.nextInt(64)];
+        sr.nextBytes(suffix);
+
+        MessageDigest md = MessageDigest.getInstance("SHAKE256-512", JostleProvider.PROVIDER_NAME);
+        md.update(prefix);
+        MessageDigest copy = (MessageDigest) md.clone();
+        copy.update(suffix);
+        byte[] cloneOut = copy.digest();
+
+        Assertions.assertEquals(64, cloneOut.length, "SHAKE256-512 must squeeze 64 bytes");
+
+        MessageDigest ref = MessageDigest.getInstance("SHAKE256-512", JostleProvider.PROVIDER_NAME);
+        ref.update(prefix);
+        ref.update(suffix);
+        Assertions.assertArrayEquals(ref.digest(), cloneOut,
+                "cloned XOF digest did not match the equivalent direct digest");
     }
 
 

--- a/jostle/src/test/java/org/openssl/jostle/test/mldsa/MLDSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/mldsa/MLDSATest.java
@@ -152,7 +152,9 @@ public class MLDSATest
             Assertions.fail();
         } catch (InvalidAlgorithmParameterException e)
         {
-            Assertions.assertEquals("only MLDSAParameterSpec is supported", e.getMessage());
+            // A foreign spec with no resolvable getName() is rejected. (The
+            // suffix is the anonymous class name, so match only the prefix.)
+            Assertions.assertTrue(e.getMessage().startsWith("unknown algorithm:"), e.getMessage());
         }
     }
 

--- a/jostle/src/test/java/org/openssl/jostle/test/provider/PQCForeignParamSpecKeyGenTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/provider/PQCForeignParamSpecKeyGenTest.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.provider;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jcajce.spec.SLHDSAParameterSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import javax.crypto.spec.IvParameterSpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * Verifies the ML-KEM / ML-DSA / SLH-DSA {@code KeyPairGenerator}s accept a
+ * <em>foreign</em> {@link AlgorithmParameterSpec} — one that is NOT Jostle's own
+ * spec type — by reflecting on its {@code getName()} method (the bc-java
+ * {@code SpecUtil.getNameFrom} pattern). The concrete foreign specs here are
+ * BouncyCastle's {@code org.bouncycastle.jcajce.spec.*ParameterSpec} classes, so
+ * code written against the BC provider can drive Jostle's generators unchanged.
+ * <p>
+ * The parameter set actually selected is asserted via the algorithm OID carried
+ * in the generated key's encoding, proving the reflected name was resolved to the
+ * right {@code OSSLKeyType} (not silently defaulted).
+ */
+public class PQCForeignParamSpecKeyGenTest
+{
+    // 128-bit-category parameter sets — usable with the JCE default SecureRandom
+    // (no strength-gate interaction; the reflection path is what's under test).
+    private static final String ML_KEM_512_OID = "2.16.840.1.101.3.4.4.1";
+    private static final String ML_DSA_44_OID = "2.16.840.1.101.3.4.3.17";
+    private static final String SLH_DSA_SHA2_128F_OID = "2.16.840.1.101.3.4.3.21";
+
+    @BeforeAll
+    public static void before()
+    {
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    @Test
+    public void mlkem_acceptsBouncyCastleParameterSpec() throws Exception
+    {
+        assertForeignSpecSelectsParamSet("ML-KEM", MLKEMParameterSpec.ml_kem_512, ML_KEM_512_OID);
+    }
+
+    @Test
+    public void mldsa_acceptsBouncyCastleParameterSpec() throws Exception
+    {
+        assertForeignSpecSelectsParamSet("ML-DSA", MLDSAParameterSpec.ml_dsa_44, ML_DSA_44_OID);
+    }
+
+    @Test
+    public void slhdsa_acceptsBouncyCastleParameterSpec() throws Exception
+    {
+        assertForeignSpecSelectsParamSet("SLH-DSA", SLHDSAParameterSpec.slh_dsa_sha2_128f, SLH_DSA_SHA2_128F_OID);
+    }
+
+    @Test
+    public void rejectsForeignSpecWithoutGetName() throws Exception
+    {
+        // IvParameterSpec has no getName() — reflection yields null, so the
+        // generator must reject it rather than NPE or silently default.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", JostleProvider.PROVIDER_NAME);
+        Assertions.assertThrows(InvalidAlgorithmParameterException.class,
+                () -> kpg.initialize(new IvParameterSpec(new byte[16])));
+    }
+
+    @Test
+    public void rejectsForeignSpecWithUnknownName() throws Exception
+    {
+        // A well-formed foreign spec whose getName() ("ML-KEM-512") is unknown to
+        // the ML-DSA generator must be rejected, not coerced.
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA", JostleProvider.PROVIDER_NAME);
+        Assertions.assertThrows(InvalidAlgorithmParameterException.class,
+                () -> kpg.initialize(MLKEMParameterSpec.ml_kem_512));
+    }
+
+    private static void assertForeignSpecSelectsParamSet(String genName, AlgorithmParameterSpec foreignSpec, String expectedOid)
+            throws Exception
+    {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(genName, JostleProvider.PROVIDER_NAME);
+        kpg.initialize(foreignSpec);
+        KeyPair kp = kpg.generateKeyPair();
+
+        String pubOid = SubjectPublicKeyInfo.getInstance(kp.getPublic().getEncoded())
+                .getAlgorithm().getAlgorithm().getId();
+        String privOid = PrivateKeyInfo.getInstance(kp.getPrivate().getEncoded())
+                .getPrivateKeyAlgorithm().getAlgorithm().getId();
+
+        Assertions.assertEquals(expectedOid, pubOid, genName + ": public key OID");
+        Assertions.assertEquals(expectedOid, privOid, genName + ": private key OID");
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSANoneWithRSASignatureTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSANoneWithRSASignatureTest.java
@@ -1,0 +1,245 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.rsa;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.util.Arrays;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+/**
+ * Tests for the raw PKCS#1 v1.5 {@code NoneWithRSA} Signature (JCA/TLS gap #4).
+ * The engine performs no hashing — the caller supplies the already-formed
+ * bytes (typically a DigestInfo) and the engine applies PKCS#1 v1.5
+ * block-type-1 padding + the RSA private-key op. Required by TLS 1.3's
+ * externally-hashed CertificateVerify.
+ */
+public class RSANoneWithRSASignatureTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /** Shared keypair (Jostle) reused across tests to bound wall-clock time. */
+    private static KeyPair joKeyPair;
+    /** BouncyCastle-native copies of the same key, for cross-provider agreement. */
+    private static PrivateKey bcPriv;
+    private static PublicKey bcPub;
+
+    /**
+     * The fixed ASN.1 DigestInfo prefix for SHA-256 (RFC 8017 §9.2):
+     * SEQUENCE { SEQUENCE { OID sha256, NULL }, OCTET STRING (32) }. The
+     * 32-byte digest is appended to form the full DigestInfo.
+     */
+    private static final byte[] SHA256_DIGESTINFO_PREFIX = {
+            (byte) 0x30, (byte) 0x31, (byte) 0x30, (byte) 0x0d,
+            (byte) 0x06, (byte) 0x09, (byte) 0x60, (byte) 0x86,
+            (byte) 0x48, (byte) 0x01, (byte) 0x65, (byte) 0x03,
+            (byte) 0x04, (byte) 0x02, (byte) 0x01, (byte) 0x05,
+            (byte) 0x00, (byte) 0x04, (byte) 0x20
+    };
+
+    private static SecureRandom seededRandom(String testName) throws Exception
+    {
+        long seed = RANDOM.nextLong();
+        System.out.println(testName + " seed=" + seed);
+        SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        sr.setSeed(seed);
+        return sr;
+    }
+
+    @BeforeAll
+    static void before() throws Exception
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        joKeyPair = kpg.generateKeyPair();
+
+        // Re-decode the same key into BC-native objects so the cross-provider
+        // agreement tests aren't entangled with cross-provider key-class
+        // acceptance (that's covered elsewhere).
+        KeyFactory bcKf = KeyFactory.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(joKeyPair.getPrivate().getEncoded()));
+        bcPub = bcKf.generatePublic(new X509EncodedKeySpec(joKeyPair.getPublic().getEncoded()));
+    }
+
+    /**
+     * NoneWithRSA over a properly-formed SHA-256 DigestInfo must produce a
+     * signature byte-identical to SHA256withRSA over the original message —
+     * SHA256withRSA is exactly "PKCS#1 v1.5 over DigestInfo(SHA-256, H(m))",
+     * and PKCS#1 v1.5 signing is deterministic. This pins that the raw engine
+     * pads the caller bytes directly (no extra DigestInfo wrapping, no hashing).
+     */
+    @Test
+    public void testNoneWithRSA_equivalentToSHA256withRSA() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithRSA_equivalentToSHA256withRSA");
+        byte[] msg = new byte[1 + sr.nextInt(512)];
+        sr.nextBytes(msg);
+
+        byte[] hash = MessageDigest.getInstance("SHA-256", JostleProvider.PROVIDER_NAME).digest(msg);
+        byte[] digestInfo = new byte[SHA256_DIGESTINFO_PREFIX.length + hash.length];
+        System.arraycopy(SHA256_DIGESTINFO_PREFIX, 0, digestInfo, 0, SHA256_DIGESTINFO_PREFIX.length);
+        System.arraycopy(hash, 0, digestInfo, SHA256_DIGESTINFO_PREFIX.length, hash.length);
+
+        Signature none = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        none.initSign(joKeyPair.getPrivate());
+        none.update(digestInfo);
+        byte[] rawSig = none.sign();
+
+        Signature full = Signature.getInstance("SHA256withRSA", JostleProvider.PROVIDER_NAME);
+        full.initSign(joKeyPair.getPrivate());
+        full.update(msg);
+        byte[] fullSig = full.sign();
+
+        Assertions.assertArrayEquals(fullSig, rawSig,
+                "NoneWithRSA(DigestInfo) must equal SHA256withRSA(message)");
+
+        // And the raw signature verifies through NoneWithRSA against the DigestInfo.
+        Signature v = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        v.initVerify(joKeyPair.getPublic());
+        v.update(digestInfo);
+        Assertions.assertTrue(v.verify(rawSig), "NoneWithRSA failed to verify its own signature");
+    }
+
+    /**
+     * Cross-provider agreement on raw bytes: JSL and BouncyCastle must produce
+     * byte-identical NoneWithRSA signatures (deterministic) and each must
+     * verify the other's. Random content and length per trial.
+     */
+    @Test
+    public void testNoneWithRSA_agreesWithBouncyCastle() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithRSA_agreesWithBouncyCastle");
+        for (int trial = 0; trial < 10; trial++)
+        {
+            // Bounded well under k - 11 (= 245 for a 2048-bit modulus).
+            byte[] tbs = new byte[1 + sr.nextInt(200)];
+            sr.nextBytes(tbs);
+
+            Signature joSign = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+            joSign.initSign(joKeyPair.getPrivate());
+            joSign.update(tbs);
+            byte[] joSig = joSign.sign();
+
+            Signature bcSign = Signature.getInstance("NoneWithRSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcSign.initSign(bcPriv);
+            bcSign.update(tbs);
+            byte[] bcSig = bcSign.sign();
+
+            Assertions.assertArrayEquals(bcSig, joSig,
+                    "deterministic NoneWithRSA signatures disagree (trial " + trial + ")");
+
+            // JSL signature verifies under BC...
+            Signature bcVerify = Signature.getInstance("NoneWithRSA", BouncyCastleProvider.PROVIDER_NAME);
+            bcVerify.initVerify(bcPub);
+            bcVerify.update(tbs);
+            Assertions.assertTrue(bcVerify.verify(joSig), "BC rejected a JSL NoneWithRSA signature");
+
+            // ...and BC's signature verifies under JSL.
+            Signature joVerify = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+            joVerify.initVerify(joKeyPair.getPublic());
+            joVerify.update(tbs);
+            Assertions.assertTrue(joVerify.verify(bcSig), "JSL rejected a BC NoneWithRSA signature");
+
+            // Negative: tampering the signed bytes must break verification.
+            byte[] tampered = Arrays.clone(tbs);
+            tampered[sr.nextInt(tampered.length)] ^= 0x01;
+            Signature joVerifyBad = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+            joVerifyBad.initVerify(joKeyPair.getPublic());
+            joVerifyBad.update(tampered);
+            Assertions.assertFalse(joVerifyBad.verify(joSig), "JSL verified a tampered message");
+        }
+    }
+
+    /**
+     * The buffered input must be chunking-invariant: a one-shot update and a
+     * byte-by-byte update of the same bytes produce the same signature.
+     */
+    @Test
+    public void testNoneWithRSA_chunkingInvariant() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithRSA_chunkingInvariant");
+        byte[] tbs = new byte[1 + sr.nextInt(200)];
+        sr.nextBytes(tbs);
+
+        Signature oneShot = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        oneShot.initSign(joKeyPair.getPrivate());
+        oneShot.update(tbs);
+        byte[] sigOneShot = oneShot.sign();
+
+        Signature byteWise = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        byteWise.initSign(joKeyPair.getPrivate());
+        for (byte b : tbs)
+        {
+            byteWise.update(b);
+        }
+        byte[] sigByteWise = byteWise.sign();
+
+        Assertions.assertArrayEquals(sigOneShot, sigByteWise,
+                "NoneWithRSA signature depends on input chunking");
+    }
+
+    /**
+     * Reuse after a terminal op: the same instance must sign two different
+     * inputs correctly (proves the native buffer is cleared on re-init).
+     */
+    @Test
+    public void testNoneWithRSA_reuseAfterSign() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNoneWithRSA_reuseAfterSign");
+        byte[] a = new byte[1 + sr.nextInt(100)];
+        byte[] b = new byte[1 + sr.nextInt(100)];
+        sr.nextBytes(a);
+        sr.nextBytes(b);
+
+        Signature signer = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        signer.initSign(joKeyPair.getPrivate());
+        signer.update(a);
+        byte[] sigA = signer.sign();
+        // Same instance, second message — no re-init.
+        signer.update(b);
+        byte[] sigB = signer.sign();
+
+        Signature ref = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        ref.initVerify(joKeyPair.getPublic());
+        ref.update(a);
+        Assertions.assertTrue(ref.verify(sigA), "first reuse signature did not verify");
+
+        ref.initVerify(joKeyPair.getPublic());
+        ref.update(b);
+        Assertions.assertTrue(ref.verify(sigB), "second reuse signature did not verify");
+
+        Assertions.assertFalse(Arrays.areEqual(sigA, sigB),
+                "distinct messages produced identical signatures (stale buffer?)");
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSANoneWithRSASignatureTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSANoneWithRSASignatureTest.java
@@ -210,6 +210,25 @@ public class RSANoneWithRSASignatureTest
     }
 
     /**
+     * PKCS#1 v1.5 signing requires the TBS to fit: {@code len <= k - 11}
+     * (245 bytes for a 2048-bit modulus). An over-long input must be rejected
+     * (OpenSSL's {@code EVP_PKEY_sign} fails) and surface as a typed exception,
+     * not silently truncate or corrupt.
+     */
+    @Test
+    public void testNoneWithRSA_inputTooLongIsRejected() throws Exception
+    {
+        byte[] tooLong = new byte[256]; // > k - 11 = 245 for RSA-2048
+        new SecureRandom().nextBytes(tooLong);
+
+        Signature signer = Signature.getInstance("NoneWithRSA", JostleProvider.PROVIDER_NAME);
+        signer.initSign(joKeyPair.getPrivate());
+        signer.update(tooLong);
+        Assertions.assertThrows(RuntimeException.class, signer::sign,
+                "NoneWithRSA accepted a TBS longer than the PKCS#1 v1.5 limit");
+    }
+
+    /**
      * Reuse after a terminal op: the same instance must sign two different
      * inputs correctly (proves the native buffer is cleared on re-init).
      */

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSAOpsTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSAOpsTest.java
@@ -1463,4 +1463,87 @@ public class RSAOpsTest
             specNI.dispose(keyRef);
         }
     }
+
+
+    // -----------------------------------------------------------------
+    // Raw PKCS#1 v1.5 (NoneWithRSA) — rsa_raw_init / raw sign / raw verify
+    // -----------------------------------------------------------------
+
+    @Test
+    public void RSA_noneRawInitSign_opensslError() throws Exception
+    {
+        Assumptions.assumeTrue(operationsTestNI.opsTestAvailable());
+        long rsaRef = rsaServiceNI.allocateSigner();
+        long keyRef = rsaServiceNI.generateKeyPair(2048, PUB_EXP_F4, TestUtil.RNDSrc);
+        try
+        {
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/rsa.c:545
+            operationsTestNI.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_11);
+            int code = rsaServiceNI.ni_initSign(rsaRef, keyRef, "NONE",
+                    RSAServiceNI.PADDING_PKCS1_NONE, null, 0, TestUtil.RNDSrc);
+            // -2 + (-1100) = -1102.
+            Assertions.assertEquals(-1102, code);
+        }
+        finally
+        {
+            operationsTestNI.resetFlags();
+            rsaServiceNI.disposeSigner(rsaRef);
+            specNI.dispose(keyRef);
+        }
+    }
+
+    @Test
+    public void RSA_noneRawSign_opensslError() throws Exception
+    {
+        Assumptions.assumeTrue(operationsTestNI.opsTestAvailable());
+        long rsaRef = rsaServiceNI.allocateSigner();
+        long keyRef = rsaServiceNI.generateKeyPair(2048, PUB_EXP_F4, TestUtil.RNDSrc);
+        try
+        {
+            int initCode = rsaServiceNI.ni_initSign(rsaRef, keyRef, "NONE",
+                    RSAServiceNI.PADDING_PKCS1_NONE, null, 0, TestUtil.RNDSrc);
+            Assertions.assertEquals(0, initCode);
+            rsaServiceNI.ni_update(rsaRef, new byte[32], 0, 32);
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/rsa.c:860
+            operationsTestNI.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_12);
+            int code = rsaServiceNI.ni_sign(rsaRef, null, 0, TestUtil.RNDSrc);
+            // -2 + (-1101) = -1103.
+            Assertions.assertEquals(-1103, code);
+        }
+        finally
+        {
+            operationsTestNI.resetFlags();
+            rsaServiceNI.disposeSigner(rsaRef);
+            specNI.dispose(keyRef);
+        }
+    }
+
+    @Test
+    public void RSA_noneRawVerify_opensslError() throws Exception
+    {
+        Assumptions.assumeTrue(operationsTestNI.opsTestAvailable());
+        long rsaRef = rsaServiceNI.allocateSigner();
+        long keyRef = rsaServiceNI.generateKeyPair(2048, PUB_EXP_F4, TestUtil.RNDSrc);
+        try
+        {
+            int initCode = rsaServiceNI.ni_initVerify(rsaRef, keyRef, "NONE",
+                    RSAServiceNI.PADDING_PKCS1_NONE, null, 0);
+            Assertions.assertEquals(0, initCode);
+            rsaServiceNI.ni_update(rsaRef, new byte[32], 0, 32);
+            OpenSSL.getOpenSSLErrors();
+            // Exercises interface/util/rsa.c:949
+            operationsTestNI.setFlag(OperationsTestNI.OpsTestFlag.OPS_OPENSSL_ERROR_11);
+            int code = rsaServiceNI.ni_verify(rsaRef, new byte[256], 256);
+            // -2 + (-1102) = -1104.
+            Assertions.assertEquals(-1104, code);
+        }
+        finally
+        {
+            operationsTestNI.resetFlags();
+            rsaServiceNI.disposeSigner(rsaRef);
+            specNI.dispose(keyRef);
+        }
+    }
 }

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
@@ -1645,6 +1645,38 @@ public class RSATest
         Assertions.assertTrue(verifier.verify(sig), "PSS round-trip with imported id-RSASSA-PSS key failed");
     }
 
+    /**
+     * {@code RSAPrivateKey.getEncoded()} must be a real PKCS#8 PrivateKeyInfo —
+     * matching the {@code getFormat() == "PKCS#8"} contract — not the
+     * traditional PKCS#1 RSAPrivateKey (JCA/TLS gap #8). A strict PKCS#8 parser
+     * (BC's {@code PrivateKeyInfo.getInstance}) must accept it, and the
+     * privateKeyAlgorithm must be rsaEncryption.
+     */
+    @Test
+    public void testPrivateKeyEncoding_isPkcs8NotPkcs1() throws Exception
+    {
+        PrivateKey priv = sharedKeyPair.getPrivate();
+        Assertions.assertEquals("PKCS#8", priv.getFormat(), "getFormat() should advertise PKCS#8");
+
+        byte[] encoded = priv.getEncoded();
+
+        // Strict PKCS#8 parse — would throw on a traditional PKCS#1 RSAPrivateKey
+        // (its second SEQUENCE element is the modulus INTEGER, not an AlgorithmIdentifier).
+        org.bouncycastle.asn1.pkcs.PrivateKeyInfo pki =
+                org.bouncycastle.asn1.pkcs.PrivateKeyInfo.getInstance(encoded);
+        Assertions.assertEquals(
+                org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.rsaEncryption,
+                pki.getPrivateKeyAlgorithm().getAlgorithm(),
+                "PKCS#8 privateKeyAlgorithm should be rsaEncryption");
+
+        // Re-decode through JSL and confirm the key still functions.
+        KeyFactory kf = KeyFactory.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        PrivateKey roundTripped = kf.generatePrivate(new PKCS8EncodedKeySpec(encoded));
+        Assertions.assertEquals(
+                ((java.security.interfaces.RSAPrivateKey) priv).getModulus(),
+                ((java.security.interfaces.RSAPrivateKey) roundTripped).getModulus());
+    }
+
     private static byte[] randomMessage(SecureRandom sr, int len)
     {
         byte[] m = new byte[len];

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
@@ -1643,6 +1643,16 @@ public class RSATest
         verifier.initVerify(jslPub);
         verifier.update(msg);
         Assertions.assertTrue(verifier.verify(sig), "PSS round-trip with imported id-RSASSA-PSS key failed");
+
+        // Negative: a tampered message must not verify — proves the imported
+        // public key actually checks the signature (not a stub that accepts all).
+        byte[] tampered = Arrays.clone(msg);
+        tampered[sr.nextInt(tampered.length)] ^= 0x01;
+        Signature badVerifier = Signature.getInstance("SHA256withRSAandMGF1", JostleProvider.PROVIDER_NAME);
+        badVerifier.initVerify(jslPub);
+        badVerifier.update(tampered);
+        Assertions.assertFalse(badVerifier.verify(sig),
+                "imported id-RSASSA-PSS key verified a tampered message");
     }
 
     /**

--- a/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/rsa/RSATest.java
@@ -1580,6 +1580,71 @@ public class RSATest
         return m;
     }
 
+    /**
+     * The RSA KeyFactory must import an {@code id-RSASSA-PSS}-tagged
+     * key (OID 1.2.840.113549.1.1.10) — the encoding TLS 1.3
+     * {@code rsa_pss_pss_*} certificates carry — treating it as a plain RSA
+     * key, as BC/SunRsaSign do (JCA/TLS gap #7). An RSASSA-PSS key is
+     * structurally identical to an rsaEncryption one.
+     */
+    @Test
+    public void testKeyFactory_importsIdRSASSAPSSEncodedKey() throws Exception
+    {
+        // Base keypair from BC so the encodings are proper PKCS#8 / X.509 that
+        // BC's ASN.1 can re-wrap (JSL's RSA getEncoded for the private key is
+        // traditional PKCS#1, which PrivateKeyInfo.getInstance won't parse).
+        KeyPairGenerator bcKpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        bcKpg.initialize(2048);
+        KeyPair bcKp = bcKpg.generateKeyPair();
+
+        // Re-wrap the same key bits under the id-RSASSA-PSS OID (params absent),
+        // the form TLS rsa_pss_pss_* certificates carry.
+        org.bouncycastle.asn1.x509.SubjectPublicKeyInfo spki =
+                org.bouncycastle.asn1.x509.SubjectPublicKeyInfo.getInstance(bcKp.getPublic().getEncoded());
+        byte[] pssPub = new org.bouncycastle.asn1.x509.SubjectPublicKeyInfo(
+                new org.bouncycastle.asn1.x509.AlgorithmIdentifier(
+                        org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.id_RSASSA_PSS),
+                spki.getPublicKeyData().getBytes()).getEncoded();
+
+        org.bouncycastle.asn1.pkcs.PrivateKeyInfo pki =
+                org.bouncycastle.asn1.pkcs.PrivateKeyInfo.getInstance(bcKp.getPrivate().getEncoded());
+        byte[] pssPriv = new org.bouncycastle.asn1.pkcs.PrivateKeyInfo(
+                new org.bouncycastle.asn1.x509.AlgorithmIdentifier(
+                        org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.id_RSASSA_PSS),
+                pki.parsePrivateKey()).getEncoded();
+
+        KeyFactory kf = KeyFactory.getInstance("RSA", JostleProvider.PROVIDER_NAME);
+        PublicKey jslPub = kf.generatePublic(new X509EncodedKeySpec(pssPub));
+        PrivateKey jslPriv = kf.generatePrivate(new PKCS8EncodedKeySpec(pssPriv));
+
+        Assertions.assertTrue(jslPub instanceof RSAPublicKey, "imported key is not an RSA public key");
+        Assertions.assertEquals(((RSAPublicKey) bcKp.getPublic()).getModulus(),
+                ((RSAPublicKey) jslPub).getModulus(), "public modulus differs after import");
+        Assertions.assertEquals(
+                ((java.security.interfaces.RSAPrivateKey) bcKp.getPrivate()).getModulus(),
+                ((java.security.interfaces.RSAPrivateKey) jslPriv).getModulus(),
+                "private modulus differs after import");
+
+        // The imported key is a plain RSA key: it re-encodes identically to a
+        // JSL import of the equivalent rsaEncryption SPKI (PSS OID is dropped).
+        PublicKey jslPlain = kf.generatePublic(new X509EncodedKeySpec(bcKp.getPublic().getEncoded()));
+        Assertions.assertArrayEquals(jslPlain.getEncoded(), jslPub.getEncoded(),
+                "imported id-RSASSA-PSS key did not canonicalise to plain rsaEncryption");
+
+        // ...and it functions: a PSS round-trip with the imported keys verifies.
+        SecureRandom sr = seededRandom("testKeyFactory_importsIdRSASSAPSSEncodedKey");
+        byte[] msg = randomMessage(sr, 1 + sr.nextInt(256));
+        Signature signer = Signature.getInstance("SHA256withRSAandMGF1", JostleProvider.PROVIDER_NAME);
+        signer.initSign(jslPriv);
+        signer.update(msg);
+        byte[] sig = signer.sign();
+
+        Signature verifier = Signature.getInstance("SHA256withRSAandMGF1", JostleProvider.PROVIDER_NAME);
+        verifier.initVerify(jslPub);
+        verifier.update(msg);
+        Assertions.assertTrue(verifier.verify(sig), "PSS round-trip with imported id-RSASSA-PSS key failed");
+    }
+
     private static byte[] randomMessage(SecureRandom sr, int len)
     {
         byte[] m = new byte[len];

--- a/jostle/src/test/java25/org/openssl/jostle/test/eddsa/EdECInterfaceTest.java
+++ b/jostle/src/test/java25/org/openssl/jostle/test/eddsa/EdECInterfaceTest.java
@@ -237,4 +237,70 @@ public class EdECInterfaceTest
                 "Jostle must verify a signature made by the reconstructed " + algorithm + " key ("
                         + (targetProv == null ? "default" : targetProv) + " provider)");
     }
+
+    //
+    // Foreign-key acceptance (JCA/TLS gap #5): JSL's Ed Signature must
+    // accept a SunEC-decoded key directly — the exact scenario the TLS
+    // 1.3 CertificateVerify path hit, where the peer key was decoded by
+    // SunEC and handed to Signature.getInstance("Ed25519","JSL").
+    //
+    @Test
+    public void testForeignKeyInterop_SunEC_Ed25519() throws Exception
+    {
+        foreignKeyInteropViaSunEC("Ed25519");
+    }
+
+    @Test
+    public void testForeignKeyInterop_SunEC_Ed448() throws Exception
+    {
+        foreignKeyInteropViaSunEC("Ed448");
+    }
+
+    private void foreignKeyInteropViaSunEC(String alg) throws Exception
+    {
+        SecureRandom sr = seededRandom("foreignKeyInteropViaSunEC_" + alg);
+
+        // SunEC-owned keypair (EdECPublicKey / EdECPrivateKey instances).
+        KeyPairGenerator sunKpg = KeyPairGenerator.getInstance(alg, "SunEC");
+        KeyPair sunKp = sunKpg.generateKeyPair();
+
+        byte[] msg = new byte[16 + sr.nextInt(256)];
+        sr.nextBytes(msg);
+
+        // Sign with SunEC, verify with JSL using SunEC's (foreign) public key.
+        Signature sunSigner = Signature.getInstance(alg, "SunEC");
+        sunSigner.initSign(sunKp.getPrivate());
+        sunSigner.update(msg);
+        byte[] sunSig = sunSigner.sign();
+
+        Signature joVerifier = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joVerifier.initVerify(sunKp.getPublic());
+        joVerifier.update(msg);
+        Assertions.assertTrue(joVerifier.verify(sunSig),
+                alg + ": JSL failed to verify a SunEC signature using SunEC's public key");
+
+        byte[] tampered = msg.clone();
+        tampered[0] ^= 1;
+        Signature joVerifier2 = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joVerifier2.initVerify(sunKp.getPublic());
+        joVerifier2.update(tampered);
+        Assertions.assertFalse(joVerifier2.verify(sunSig),
+                alg + ": JSL verified a tampered message");
+
+        // Sign with JSL using SunEC's (foreign) private key, verify with SunEC.
+        Signature joSigner = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        joSigner.initSign(sunKp.getPrivate());
+        joSigner.update(msg);
+        byte[] joSig = joSigner.sign();
+
+        Signature sunVerifier = Signature.getInstance(alg, "SunEC");
+        sunVerifier.initVerify(sunKp.getPublic());
+        sunVerifier.update(msg);
+        Assertions.assertTrue(sunVerifier.verify(joSig),
+                alg + ": SunEC failed to verify a JSL signature made with SunEC's private key");
+
+        // EdDSA is deterministic — signatures must match byte-for-byte.
+        Assertions.assertArrayEquals(sunSig, joSig,
+                alg + ": deterministic EdDSA signatures disagree between SunEC and JSL");
+    }
 }

--- a/jostle/src/test/java25/org/openssl/jostle/test/eddsa/EdECInterfaceTest.java
+++ b/jostle/src/test/java25/org/openssl/jostle/test/eddsa/EdECInterfaceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.util.Arrays;
 
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -279,7 +280,7 @@ public class EdECInterfaceTest
         Assertions.assertTrue(joVerifier.verify(sunSig),
                 alg + ": JSL failed to verify a SunEC signature using SunEC's public key");
 
-        byte[] tampered = msg.clone();
+        byte[] tampered = Arrays.clone(msg);
         tampered[0] ^= 1;
         Signature joVerifier2 = Signature.getInstance(alg, JostleProvider.PROVIDER_NAME);
         joVerifier2.initVerify(sunKp.getPublic());

--- a/jostle/src/test/java25/org/openssl/jostle/test/provider/PQCNamedParameterSpecKeyGenTest.java
+++ b/jostle/src/test/java25/org/openssl/jostle/test/provider/PQCNamedParameterSpecKeyGenTest.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.provider;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.spec.NamedParameterSpec;
+
+/**
+ * Companion to {@code PQCForeignParamSpecKeyGenTest} for the later-JVM source set:
+ * drives the ML-KEM / ML-DSA / SLH-DSA {@code KeyPairGenerator}s with the JDK's own
+ * {@link NamedParameterSpec} (added in Java 9 / RFC-era PQC support landed Java 11+).
+ * It is a foreign {@link java.security.spec.AlgorithmParameterSpec} carrying a
+ * {@code getName()}, so it must be accepted via the same reflective name-resolution
+ * path as BouncyCastle's specs — confirming the support is not specific to BC's
+ * spec classes. NamedParameterSpec is unavailable at the Java 8 baseline, which is
+ * why this test lives in {@code src/test/java25}.
+ */
+public class PQCNamedParameterSpecKeyGenTest
+{
+    private static final String ML_KEM_512_OID = "2.16.840.1.101.3.4.4.1";
+    private static final String ML_DSA_44_OID = "2.16.840.1.101.3.4.3.17";
+    private static final String SLH_DSA_SHA2_128F_OID = "2.16.840.1.101.3.4.3.21";
+
+    @BeforeAll
+    public static void before()
+    {
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    @Test
+    public void mlkem_acceptsNamedParameterSpec() throws Exception
+    {
+        assertNamedSpecSelectsParamSet("ML-KEM", "ML-KEM-512", ML_KEM_512_OID);
+    }
+
+    @Test
+    public void mldsa_acceptsNamedParameterSpec() throws Exception
+    {
+        assertNamedSpecSelectsParamSet("ML-DSA", "ML-DSA-44", ML_DSA_44_OID);
+    }
+
+    @Test
+    public void slhdsa_acceptsNamedParameterSpec() throws Exception
+    {
+        assertNamedSpecSelectsParamSet("SLH-DSA", "SLH-DSA-SHA2-128F", SLH_DSA_SHA2_128F_OID);
+    }
+
+    private static void assertNamedSpecSelectsParamSet(String genName, String paramSetName, String expectedOid)
+            throws Exception
+    {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(genName, JostleProvider.PROVIDER_NAME);
+        kpg.initialize(new NamedParameterSpec(paramSetName));
+        KeyPair kp = kpg.generateKeyPair();
+
+        String pubOid = SubjectPublicKeyInfo.getInstance(kp.getPublic().getEncoded())
+                .getAlgorithm().getAlgorithm().getId();
+        String privOid = PrivateKeyInfo.getInstance(kp.getPrivate().getEncoded())
+                .getPrivateKeyAlgorithm().getAlgorithm().getId();
+
+        Assertions.assertEquals(expectedOid, pubOid, genName + ": public key OID");
+        Assertions.assertEquals(expectedOid, privOid, genName + ": private key OID");
+    }
+}


### PR DESCRIPTION
Also single-cased parameterSpec lookups, tests for the same and dealt with some compatibility issues with BCJSSE. Added NONEwithRSA, NONEwithECDSA for authentication, zeroization of some private key specs, minor additional refactoring. Also cloning of message digests. Corrected encodings of RSA private keys (PKCS#8 wrapper missing).

PR provides full support for TLS 1.3 signature methods.