### PR TITLE
Add missing algorithm parameters, use of HKDF as a KeyFactory, reflection based processing of AEADParameterSpec

### DIFF
--- a/interface/ffi/kdf_ffi.c
+++ b/interface/ffi/kdf_ffi.c
@@ -176,3 +176,66 @@ int32_t KDF_SCRYPT(
 exit:
     return ret_code;
 }
+
+
+int32_t KDF_HKDF(
+    uint8_t *ikm, size_t ikm_len,
+    uint8_t *salt, size_t salt_len,
+    uint8_t *info, size_t info_len,
+    uint8_t *digest_name, size_t digest_name_len,
+    uint8_t *output, size_t out_size,
+    int32_t out_offset,
+    int32_t out_len
+) {
+    int32_t ret_code = JO_FAIL;
+
+    if (ikm == NULL) {
+        ret_code = JO_KDF_HKDF_IKM_NULL;
+        goto exit;
+    }
+
+    // salt and info are optional (NULL accepted); no null-check here.
+
+    if (output == NULL) {
+        ret_code = JO_OUTPUT_IS_NULL;
+        goto exit;
+    }
+
+    if (out_offset < 0) {
+        ret_code = JO_OUTPUT_OFFSET_IS_NEGATIVE;
+        goto exit;
+    }
+
+    if (out_len < 0) {
+        ret_code = JO_OUTPUT_LEN_IS_NEGATIVE;
+        goto exit;
+    }
+
+    if (!check_in_range(out_size, out_offset, out_len)) {
+        ret_code = JO_OUTPUT_OUT_OF_RANGE;
+        goto exit;
+    }
+
+    if (digest_name == NULL) {
+        ret_code = JO_KDF_PBE_UNKNOWN_DIGEST;
+        goto exit;
+    }
+
+    if (digest_name_len == 0) {
+        ret_code = JO_KDF_PBE_UNKNOWN_DIGEST;
+        goto exit;
+    }
+
+    uint8_t *out = output + out_offset;
+
+    ret_code = hkdf(
+        ikm, ikm_len,
+        salt, salt_len,
+        info, info_len,
+        digest_name, digest_name_len,
+        out, out_len);
+
+
+exit:
+    return ret_code;
+}

--- a/interface/jni/kdf_jni.c
+++ b/interface/jni/kdf_jni.c
@@ -248,3 +248,120 @@ exit:
 
     return ret_code;
 }
+
+
+/*
+ * Class:     org_openssl_jostle_jcajce_provider_kdf_KdfNIJNI
+ * Method:    hkdf
+ * Signature: ([B[B[BLjava/lang/String;[BII)I
+ */
+JNIEXPORT jint JNICALL Java_org_openssl_jostle_jcajce_provider_kdf_KdfNIJNI_hkdf
+(JNIEnv *env, jobject jo, jbyteArray _ikm, jbyteArray _salt, jbyteArray _info, jstring digest, jbyteArray _out,
+ jint out_offset, jint out_len) {
+    UNUSED(jo);
+
+    int ret_code = JO_FAIL;
+    const char *digest_str = NULL;
+    jsize digest_str_len = 0;
+
+    java_bytearray_ctx ikm;
+    java_bytearray_ctx salt;
+    java_bytearray_ctx info;
+    java_bytearray_ctx output;
+
+    init_bytearray_ctx(&ikm);
+    init_bytearray_ctx(&salt);
+    init_bytearray_ctx(&info);
+    init_bytearray_ctx(&output);
+
+    if (OPS_FAILED_ACCESS_1 !load_bytearray_ctx(&ikm, env, _ikm)) {
+        ret_code = JO_KDF_HKDF_IKM_FAILED_ACCESS;
+        goto exit;
+    }
+
+    if (ikm.array == NULL) {
+        ret_code = JO_KDF_HKDF_IKM_NULL;
+        goto exit;
+    }
+
+
+    // salt is optional; a null array means "use HashLen zeros" (RFC 5869).
+    if (OPS_FAILED_ACCESS_2 !load_bytearray_ctx(&salt, env, _salt)) {
+        ret_code = JO_KDF_SALT_FAILED_ACCESS;
+        goto exit;
+    }
+
+
+    // info is optional; a null array means "no context info".
+    if (OPS_FAILED_ACCESS_3 !load_bytearray_ctx(&info, env, _info)) {
+        ret_code = JO_KDF_HKDF_INFO_FAILED_ACCESS;
+        goto exit;
+    }
+
+
+    if (OPS_FAILED_ACCESS_4 !load_bytearray_ctx(&output, env, _out)) {
+        ret_code = JO_FAILED_ACCESS_OUTPUT;
+        goto exit;
+    }
+
+    if (output.array == NULL) {
+        ret_code = JO_OUTPUT_IS_NULL;
+        goto exit;
+    }
+
+    if (out_offset < 0) {
+        ret_code = JO_OUTPUT_OFFSET_IS_NEGATIVE;
+        goto exit;
+    }
+
+    if (out_len < 0) {
+        ret_code = JO_OUTPUT_LEN_IS_NEGATIVE;
+        goto exit;
+    }
+
+    if (!check_bytearray_in_range(&output, out_offset, out_len)) {
+        ret_code = JO_OUTPUT_OUT_OF_RANGE;
+        goto exit;
+    }
+
+    if (digest == NULL) {
+        ret_code = JO_KDF_PBE_UNKNOWN_DIGEST;
+        goto exit;
+    }
+
+    digest_str_len = (*env)->GetStringUTFLength(env, digest);
+    if (digest_str_len <= 0) {
+        ret_code = JO_KDF_PBE_UNKNOWN_DIGEST;
+        goto exit;
+    }
+
+    digest_str = (*env)->GetStringUTFChars(env, digest, NULL);
+    if (digest_str == NULL) {
+        ret_code = JO_UNABLE_TO_ACCESS_NAME;
+        goto exit;
+    }
+
+    // out_offset is not negative by this point
+    uint8_t *out = output.bytearray + out_offset;
+
+    ret_code = hkdf(
+        ikm.bytearray, ikm.size,
+        salt.bytearray, salt.size,
+        info.bytearray, info.size,
+        (uint8_t *) digest_str,
+        digest_str_len,
+        out, out_len);
+
+
+exit:
+    release_bytearray_ctx(&ikm);
+    release_bytearray_ctx(&salt);
+    release_bytearray_ctx(&info);
+    release_bytearray_ctx(&output);
+
+    if (digest_str != NULL) {
+        (*env)->ReleaseStringUTFChars(env, digest, digest_str);
+    }
+
+    return ret_code;
+}

--- a/interface/util/bc_err_codes.h
+++ b/interface/util/bc_err_codes.h
@@ -169,6 +169,25 @@
  */
 #define JO_MD_COPY_FAILED -115
 
+/*
+ * HKDF input keying material (IKM) is null. The IKM is mandatory for
+ * HKDF-Extract; the bridge rejects a null IKM array. Distinct from the
+ * password/salt KDF codes so the HKDF surface reports the correct field.
+ */
+#define JO_KDF_HKDF_IKM_NULL -116
+
+/*
+ * The JNI critical/array load of the HKDF IKM byte array failed.
+ */
+#define JO_KDF_HKDF_IKM_FAILED_ACCESS -117
+
+/*
+ * The JNI critical/array load of the HKDF info byte array failed. The info
+ * field is optional (a null array is accepted as "no info"); this code only
+ * fires on a genuine JVM access failure of a supplied array.
+ */
+#define JO_KDF_HKDF_INFO_FAILED_ACCESS -118
+
 
 
 #define UNSUCCESSFUL(x) JO_SUCCESS > x

--- a/interface/util/kdf.c
+++ b/interface/util/kdf.c
@@ -131,3 +131,68 @@ exit:
     return ret;
 }
 
+
+int32_t hkdf(
+    uint8_t *ikm, size_t ikm_len,
+    uint8_t *salt, size_t salt_len,
+    uint8_t *info, size_t info_len,
+    uint8_t *digest, size_t digest_len,
+    uint8_t *out, size_t out_len
+) {
+    // IKM, digest and out are mandatory and validated by the bridge.
+    // salt and info are optional: a NULL salt means "use HashLen zeros"
+    // (RFC 5869), a NULL/empty info means "no context info".
+    jo_assert(ikm != NULL);
+    jo_assert(digest != NULL);
+    jo_assert(out != NULL);
+
+    int ret = JO_FAIL;
+    EVP_KDF *kdf = NULL;
+    EVP_KDF_CTX *kctx = NULL;
+
+    ERR_clear_error();
+
+    kdf = EVP_KDF_fetch(get_global_jostle_ossl_lib_ctx(), "HKDF", NULL);
+    if (OPS_OPENSSL_ERROR_1 kdf == NULL) {
+        ret = JO_OPENSSL_ERROR;
+        goto exit;
+    }
+
+    kctx = EVP_KDF_CTX_new(kdf);
+
+    if (OPS_OPENSSL_ERROR_2 !kctx) {
+        ret = JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_2(3000);
+        goto exit;
+    }
+
+    // Hard-code the HKDF mode to RFC 5869 extract-and-expand. This is the
+    // EVP_KDF "HKDF" default, but set it explicitly so the one-shot semantics
+    // the consumers rely on survive a default change or a custom provider.
+    // DO NOT change this value.
+    int mode = EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND;
+
+    OSSL_PARAM params[6];
+    int idx = 0;
+    params[idx++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode);
+    params[idx++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, (char *) digest, digest_len);
+    params[idx++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, ikm, ikm_len);
+    if (salt != NULL) {
+        params[idx++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, salt, salt_len);
+    }
+    if (info != NULL && info_len > 0) {
+        params[idx++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, info, info_len);
+    }
+    params[idx++] = OSSL_PARAM_construct_end();
+
+    if (OPS_OPENSSL_ERROR_3 EVP_KDF_derive(kctx, out, out_len, params) <= 0) {
+        ret = JO_OPENSSL_ERROR OPS_OFFSET_OPENSSL_ERROR_3(3001);
+        goto exit;
+    }
+
+    ret = JO_SUCCESS;
+exit:
+    EVP_KDF_free(kdf);
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+

--- a/interface/util/kdf.h
+++ b/interface/util/kdf.h
@@ -32,4 +32,12 @@ int32_t pbkdf2(
     size_t out_len
 );
 
+int32_t hkdf(
+    uint8_t *ikm, size_t ikm_len,
+    uint8_t *salt, size_t salt_len,
+    uint8_t *info, size_t info_len,
+    uint8_t *digest, size_t digest_len,
+    uint8_t *out, size_t out_len
+);
+
 #endif //KDF_H

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ErrorCode.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ErrorCode.java
@@ -149,6 +149,15 @@ public enum ErrorCode
     // EVP_MD_CTX_copy_ex failed while cloning a digest context.
     JO_MD_COPY_FAILED(-115),
 
+    // HKDF input keying material (IKM) is null.
+    JO_KDF_HKDF_IKM_NULL(-116),
+
+    // JVM access of the HKDF IKM byte array failed.
+    JO_KDF_HKDF_IKM_FAILED_ACCESS(-117),
+
+    // JVM access of the HKDF info byte array failed.
+    JO_KDF_HKDF_INFO_FAILED_ACCESS(-118),
+
     JO_UNKNOWN(Integer.MIN_VALUE);
 
     private final int code;

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/JostleProvider.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/JostleProvider.java
@@ -96,6 +96,7 @@ public class JostleProvider
         new ProvMLKEM().configure(this);
         new ProvPBKDF().configure(this);
         new ProvScryptKDF().configure(this);
+        new ProvHKDF().configure(this);
         new ProvMD().configure(this);
         new ProvED().configure(this);
         new ProvRSA().configure(this);

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvAES.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvAES.java
@@ -67,13 +67,25 @@ class ProvAES
         provider.addAlgorithmImplementation("KeyGenerator", "AES256", PREFIX + "AESKeyGen256", generalAesAttributes, (arg) -> new AESKeyGenerator(256));
         provider.addAlias("KeyGenerator", "AES256", NISTObjectIdentifiers.id_aes256_ECB, NISTObjectIdentifiers.id_aes256_CBC, NISTObjectIdentifiers.id_aes256_GCM, NISTObjectIdentifiers.id_aes256_wrap, NISTObjectIdentifiers.id_aes256_wrap_pad);
 
-        // AES-GCM AlgorithmParameters, registered under the GCM OIDs only (see
-        // GCMAlgorithmParameters). Lets OID-driven callers — notably CMS
-        // EnvelopedData decryption — parse the stored GCMParameters (nonce/ICV)
-        // via AlgorithmParameters.getInstance(<aes-gcm-oid>, "JSL").
+        // AES-GCM AlgorithmParameters, registered under the bare name "GCM" and
+        // the GCM OIDs (see GCMAlgorithmParameters). Lets OID-driven callers —
+        // notably CMS EnvelopedData decryption — parse the stored GCMParameters
+        // (nonce/ICV) via AlgorithmParameters.getInstance(<aes-gcm-oid>, "JSL"),
+        // and name-driven callers resolve it via getInstance("GCM", "JSL"). The
+        // delegate is resolved from a non-Jostle provider so the bare name can't
+        // recurse.
+        provider.addAlgorithmImplementation("AlgorithmParameters", "GCM", PREFIX + "GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
         provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes128_GCM, PREFIX + "AES128GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
         provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes192_GCM, PREFIX + "AES192GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
         provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes256_GCM, PREFIX + "AES256GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
+
+        // AES-CCM AlgorithmParameters, registered under the bare name "CCM" and
+        // the CCM OIDs (see CCMAlgorithmParameters). No JDK provider ships a CCM
+        // AlgorithmParameters, so this one is self-contained (RFC 5084 codec).
+        provider.addAlgorithmImplementation("AlgorithmParameters", "CCM", PREFIX + "CCMParameters", generalAesAttributes, (arg) -> new CCMAlgorithmParameters());
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes128_CCM, PREFIX + "AES128CCMParameters", generalAesAttributes, (arg) -> new CCMAlgorithmParameters());
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes192_CCM, PREFIX + "AES192CCMParameters", generalAesAttributes, (arg) -> new CCMAlgorithmParameters());
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes256_CCM, PREFIX + "AES256CCMParameters", generalAesAttributes, (arg) -> new CCMAlgorithmParameters());
 
         // AES-CBC AlgorithmParameters, registered under the CBC OIDs only (see
         // CBCAlgorithmParameters). Lets OID-driven callers — notably BC's PBES2 /

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvAES.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvAES.java
@@ -75,6 +75,14 @@ class ProvAES
         provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes192_GCM, PREFIX + "AES192GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
         provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes256_GCM, PREFIX + "AES256GCMParameters", generalAesAttributes, (arg) -> new GCMAlgorithmParameters());
 
+        // AES-CBC AlgorithmParameters, registered under the CBC OIDs only (see
+        // CBCAlgorithmParameters). Lets OID-driven callers — notably BC's PBES2 /
+        // PKCS#8 / PKCS#12 decryptors — recover the stored IV via
+        // AlgorithmParameters.getInstance(<aes-cbc-oid>, "JSL").
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes128_CBC, PREFIX + "AES128CBCParameters", generalAesAttributes, (arg) -> new CBCAlgorithmParameters());
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes192_CBC, PREFIX + "AES192CBCParameters", generalAesAttributes, (arg) -> new CBCAlgorithmParameters());
+        provider.addAlgorithmImplementation("AlgorithmParameters", NISTObjectIdentifiers.id_aes256_CBC, PREFIX + "AES256CBCParameters", generalAesAttributes, (arg) -> new CBCAlgorithmParameters());
+
         // AES/CCM — separate SPI because CCM is one-shot at the
         // OpenSSL layer (total plaintext length must be known up-front,
         // AAD must be passed in a single call). Registering with the

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvHKDF.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/ProvHKDF.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider;
+
+import org.openssl.jostle.jcajce.provider.kdf.HKDFSecretKeyFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class ProvHKDF
+{
+    private static final Map<String, String> generalKDFAttributes = new HashMap<String, String>();
+
+    static
+    {
+        generalKDFAttributes.put("SupportedKeyFormats", "RAW");
+    }
+
+    private static final String PREFIX = ProvHKDF.class.getName();
+
+    public void configure(final JostleProvider provider)
+    {
+        provider.addAlgorithmImplementation("SecretKeyFactory", "HKDF-SHA256", PREFIX + "SHA256", generalKDFAttributes, (arg) -> new HKDFSecretKeyFactory("SHA-256"));
+        provider.addAlgorithmImplementation("SecretKeyFactory", "HKDF-SHA384", PREFIX + "SHA384", generalKDFAttributes, (arg) -> new HKDFSecretKeyFactory("SHA-384"));
+        provider.addAlgorithmImplementation("SecretKeyFactory", "HKDF-SHA512", PREFIX + "SHA512", generalKDFAttributes, (arg) -> new HKDFSecretKeyFactory("SHA-512"));
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/AEADParameterSpecAccessor.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/AEADParameterSpecAccessor.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+package org.openssl.jostle.jcajce.provider.blockcipher;
+
+import javax.crypto.spec.IvParameterSpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * Structural accessor for BouncyCastle's
+ * {@code org.bouncycastle.jcajce.spec.AEADParameterSpec} without a compile-time
+ * dependency on it — the same reflective-foreign-spec pattern the KDF factories
+ * use for BC's {@code ScryptKeySpec}.
+ *
+ * <p>{@code AEADParameterSpec} extends {@link IvParameterSpec} and additionally
+ * carries an AEAD tag length ({@code getMacSizeInBits()}) and associated data
+ * ({@code getAssociatedData()}). Because it is an {@code IvParameterSpec}
+ * subclass, a plain {@code instanceof IvParameterSpec} check in an AEAD cipher
+ * SPI swallows it and silently drops both extra fields — the tag is then
+ * computed without the AAD, producing a valid-looking but wrong tag (and a
+ * {@code bad tag} on the decrypt side). This accessor lets the SPI recognise
+ * and honour the spec instead.
+ *
+ * <p>Shared by the multi-release {@code BlockCipherSpi} copies (this class is
+ * not version-specific), so the reflection lives in exactly one place.
+ */
+final class AEADParameterSpecAccessor
+{
+    private final byte[] iv;
+    private final int macSizeInBits;
+    private final byte[] associatedData;
+
+    private AEADParameterSpecAccessor(byte[] iv, int macSizeInBits, byte[] associatedData)
+    {
+        this.iv = iv;
+        this.macSizeInBits = macSizeInBits;
+        this.associatedData = associatedData;
+    }
+
+    byte[] getIV()
+    {
+        return iv;
+    }
+
+    int getMacSizeInBits()
+    {
+        return macSizeInBits;
+    }
+
+    byte[] getAssociatedData()
+    {
+        return associatedData;
+    }
+
+    /**
+     * True if {@code spec} is an {@link IvParameterSpec} that also exposes the
+     * {@code getMacSizeInBits()} and {@code getAssociatedData()} accessors of a
+     * BouncyCastle {@code AEADParameterSpec}.
+     */
+    static boolean matches(AlgorithmParameterSpec spec)
+    {
+        if (!(spec instanceof IvParameterSpec))
+        {
+            return false;
+        }
+        Class<?> cls = spec.getClass();
+        return hasNoArgMethod(cls, "getMacSizeInBits") && hasNoArgMethod(cls, "getAssociatedData");
+    }
+
+    /**
+     * Reflectively read the AEAD fields. {@link #matches(AlgorithmParameterSpec)}
+     * must have returned true for {@code spec}. A spec that doesn't expose the
+     * expected accessors (or whose return types differ) surfaces as
+     * {@link InvalidAlgorithmParameterException}.
+     */
+    static AEADParameterSpecAccessor extract(AlgorithmParameterSpec spec) throws InvalidAlgorithmParameterException
+    {
+        try
+        {
+            byte[] iv = ((IvParameterSpec) spec).getIV();
+            int mac = (Integer) spec.getClass().getMethod("getMacSizeInBits").invoke(spec);
+            byte[] aad = (byte[]) spec.getClass().getMethod("getAssociatedData").invoke(spec);
+            return new AEADParameterSpecAccessor(iv, mac, aad);
+        }
+        catch (ReflectiveOperationException | ClassCastException | NullPointerException e)
+        {
+            throw new InvalidAlgorithmParameterException("unsupported AEAD parameter spec: " + spec, e);
+        }
+    }
+
+    private static boolean hasNoArgMethod(Class<?> cls, String name)
+    {
+        try
+        {
+            cls.getMethod(name);
+            return true;
+        }
+        catch (NoSuchMethodException e)
+        {
+            return false;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -19,6 +19,7 @@ import org.openssl.jostle.util.Arrays;
 import org.openssl.jostle.util.Strings;
 
 import javax.crypto.*;
+import javax.crypto.interfaces.PBEKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -845,6 +846,18 @@ class BlockCipherSpi extends CipherSpi
 
     protected void validateKeyAlg(Key key) throws InvalidKeyException
     {
+        // A password/KDF-derived key (PBKDF2 or scrypt — a javax.crypto PBEKey)
+        // is generic RAW key material whose owning algorithm is the PBES2 /
+        // PKCS#8 EncryptionScheme, not a competing cipher; accept it for any
+        // cipher (the native layer still validates the key length). A key
+        // explicitly tagged for a different cipher family — e.g. an "ARIA"
+        // SecretKeySpec on an AES cipher — is not a PBEKey and is still rejected
+        // by the name check below.
+        if (key instanceof PBEKey)
+        {
+            return;
+        }
+
         String alg = key.getAlgorithm();
         if (alg != null)
         {

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -232,8 +232,12 @@ class BlockCipherSpi extends CipherSpi
             try
             {
                 AlgorithmParameters params;
-                if (osslMode == OSSLMode.GCM)
+                if (isAeadMode())
                 {
+                    // GCM AlgorithmParameters is the de-facto JCE holder for any
+                    // AEAD tag+nonce; OCB has no JCE-standard parameters type, so
+                    // it reuses GCM's. The tag length is preserved on round-trip
+                    // (a plain IvParameterSpec would drop it).
                     params = AlgorithmParameters.getInstance("GCM");
                     params.init(new GCMParameterSpec(tagLen * 8, ivBytes));
                 }
@@ -300,7 +304,7 @@ class BlockCipherSpi extends CipherSpi
                     iv = new byte[ivLen];
                     SecureRandom rng = (random != null) ? random : CryptoServicesRegistrar.getSecureRandom();
                     rng.nextBytes(iv);
-                    tag = (osslMode == OSSLMode.GCM) ? 16 : 0;
+                    tag = isAeadMode() ? 16 : 0;
                 }
                 else
                 {
@@ -313,14 +317,7 @@ class BlockCipherSpi extends CipherSpi
                 if (params instanceof IvParameterSpec)
                 {
                     iv = ((IvParameterSpec) params).getIV();
-                    if (osslMode == OSSLMode.GCM)
-                    {
-                        tag = 16;
-                    }
-                    else
-                    {
-                        tag = 0;
-                    }
+                    tag = isAeadMode() ? 16 : 0;
                 }
                 else
                 {
@@ -390,6 +387,20 @@ class BlockCipherSpi extends CipherSpi
         default:
             return engineGetBlockSize();
         }
+    }
+
+    /**
+     * True for the AEAD modes this SPI drives (GCM and OCB). Both append an
+     * authentication tag and default to a 16-byte tag when the caller doesn't
+     * specify one via a {@link GCMParameterSpec}. CCM is handled by a dedicated
+     * SPI and is not seen here. The default-16 applies to OCB as well as GCM:
+     * leaving OCB's tag length at 0 left OpenSSL's OCB cipher with no tag length
+     * established, which surfaced as {@code aes_ocb_get_ctx_params: invalid tag
+     * length} at the {@code EVP_CTRL_AEAD_GET_TAG} step on encrypt.
+     */
+    private boolean isAeadMode()
+    {
+        return osslMode == OSSLMode.GCM || osslMode == OSSLMode.OCB;
     }
 
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -283,6 +283,9 @@ class BlockCipherSpi extends CipherSpi
             ensureNativeReference();
             final byte[] iv;
             final int tag;
+            // Associated data carried by a BC AEADParameterSpec, fed to the
+            // native layer after a successful init (see below). Null otherwise.
+            byte[] aeadAssociatedData = null;
             blockSize = 0;
             // The native layer only knows ENCRYPT/DECRYPT. WRAP/UNWRAP (used for
             // key-wrap modes) map onto encrypt/decrypt respectively.
@@ -312,35 +315,46 @@ class BlockCipherSpi extends CipherSpi
                     tag = 0;
                 }
             }
+            else if (isAeadMode() && AEADParameterSpecAccessor.matches(params))
+            {
+                // BC's AEADParameterSpec extends IvParameterSpec; unwrap it here,
+                // BEFORE the IvParameterSpec branch, so its tag length and
+                // associated data are honoured rather than silently dropped (the
+                // dropped-AAD case produces a wrong-but-valid-looking tag).
+                AEADParameterSpecAccessor acc = AEADParameterSpecAccessor.extract(params);
+                int tLen = acc.getMacSizeInBits();
+                if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
+                {
+                    throw new InvalidAlgorithmParameterException(
+                            "AEAD tag length must be 32 to 128 bits and a multiple of 8");
+                }
+                iv = acc.getIV();
+                tag = tLen / 8;
+                aeadAssociatedData = acc.getAssociatedData();
+            }
+            else if (params instanceof IvParameterSpec)
+            {
+                iv = ((IvParameterSpec) params).getIV();
+                tag = isAeadMode() ? 16 : 0;
+            }
+            else if (params instanceof GCMParameterSpec)
+            {
+                int tLen = ((GCMParameterSpec) params).getTLen();
+                // Reject malformed AEAD tag lengths at the JCE boundary —
+                // BouncyCastle's 32–128-bit, multiple-of-8 range, which the
+                // cross-provider agreement tests rely on — rather than
+                // passing an out-of-spec length down to OpenSSL.
+                if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
+                {
+                    throw new InvalidAlgorithmParameterException(
+                            "AEAD tag length must be 32 to 128 bits and a multiple of 8");
+                }
+                iv = ((GCMParameterSpec) params).getIV();
+                tag = tLen / 8;
+            }
             else
             {
-                if (params instanceof IvParameterSpec)
-                {
-                    iv = ((IvParameterSpec) params).getIV();
-                    tag = isAeadMode() ? 16 : 0;
-                }
-                else
-                {
-                    if (params instanceof GCMParameterSpec)
-                    {
-                        int tLen = ((GCMParameterSpec) params).getTLen();
-                        // Reject malformed AEAD tag lengths at the JCE boundary —
-                        // BouncyCastle's 32–128-bit, multiple-of-8 range, which the
-                        // cross-provider agreement tests rely on — rather than
-                        // passing an out-of-spec length down to OpenSSL.
-                        if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
-                        {
-                            throw new InvalidAlgorithmParameterException(
-                                    "AEAD tag length must be 32 to 128 bits and a multiple of 8");
-                        }
-                        iv = ((GCMParameterSpec) params).getIV();
-                        tag = tLen / 8;
-                    }
-                    else
-                    {
-                        throw new InvalidAlgorithmParameterException("unsupported parameter spec: " + params);
-                    }
-                }
+                throw new InvalidAlgorithmParameterException("unsupported parameter spec: " + params);
             }
 
             this.ivBytes = iv;
@@ -361,6 +375,15 @@ class BlockCipherSpi extends CipherSpi
                 {
                     Arrays.fill(keyBytes, (byte) 0);
                 }
+            }
+
+            // Init succeeded: feed any AEADParameterSpec-supplied associated data
+            // now — after init, before any plaintext — so it's authenticated.
+            // This is the same native call engineUpdateAAD makes; the reuse guard
+            // is unnecessary here because the cipher was just (re)initialised.
+            if (aeadAssociatedData != null && aeadAssociatedData.length > 0)
+            {
+                blockCipherNi.updateAAD(refWrapper.getReference(), aeadAssociatedData, 0, aeadAssociatedData.length);
             }
 
             engineGetBlockSize();

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CBCAlgorithmParameters.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CBCAlgorithmParameters.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.blockcipher;
+
+import java.io.IOException;
+import java.security.AlgorithmParameters;
+import java.security.AlgorithmParametersSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+
+/**
+ * {@code AlgorithmParameters} for AES-CBC, registered under the AES-CBC OIDs so
+ * that callers which resolve the IV parameters by OID through this provider —
+ * notably BouncyCastle's PBES2 / PKCS#8 / PKCS#12 decryptors, which do
+ * {@code helper.createAlgorithmParameters(<aes-cbc-oid>)} to parse the stored IV
+ * {@code OCTET STRING} — can obtain a working instance from "JSL". The ASN.1
+ * codec and the {@link javax.crypto.spec.IvParameterSpec} translation are
+ * delegated to the JDK's own "AES" {@code AlgorithmParameters}.
+ * <p>
+ * Mirrors {@link GCMAlgorithmParameters}: the delegate is looked up via
+ * {@code AlgorithmParameters.getInstance("AES")} (no provider), and this class
+ * is deliberately registered only by OID — never under the bare name "AES" —
+ * so the delegate lookup keeps resolving to the JDK provider and cannot recurse
+ * back into this class.
+ */
+public class CBCAlgorithmParameters
+    extends AlgorithmParametersSpi
+{
+    private final AlgorithmParameters delegate;
+
+    public CBCAlgorithmParameters()
+    {
+        try
+        {
+            this.delegate = AlgorithmParameters.getInstance("AES");
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new IllegalStateException("no AES AlgorithmParameters available from the platform", e);
+        }
+    }
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+        throws InvalidParameterSpecException
+    {
+        delegate.init(paramSpec);
+    }
+
+    @Override
+    protected void engineInit(byte[] params)
+        throws IOException
+    {
+        delegate.init(params);
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format)
+        throws IOException
+    {
+        delegate.init(params, format);
+    }
+
+    @Override
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
+        throws InvalidParameterSpecException
+    {
+        return delegate.getParameterSpec(paramSpec);
+    }
+
+    @Override
+    protected byte[] engineGetEncoded()
+        throws IOException
+    {
+        return delegate.getEncoded();
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format)
+        throws IOException
+    {
+        return delegate.getEncoded(format);
+    }
+
+    @Override
+    protected String engineToString()
+    {
+        return delegate.toString();
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CCMAlgorithmParameters.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CCMAlgorithmParameters.java
@@ -1,0 +1,334 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.jcajce.provider.blockcipher;
+
+import org.openssl.jostle.util.Arrays;
+
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+
+/**
+ * {@code AlgorithmParameters} for AES-CCM, registered under the bare name
+ * {@code "CCM"} and the AES-CCM OIDs. Unlike GCM, no standard JDK provider
+ * supplies a CCM {@code AlgorithmParameters}, so this implementation is
+ * self-contained: it carries the nonce + ICV length and codes the RFC 5084
+ * {@code CCMParameters} structure directly.
+ *
+ * <pre>
+ *   CCMParameters ::= SEQUENCE {
+ *       aes-nonce    OCTET STRING (SIZE(7..13)),
+ *       aes-ICVlen   AES-CCM-ICVlen DEFAULT 12 }
+ *   AES-CCM-ICVlen ::= INTEGER (4 | 6 | 8 | 10 | 12 | 14 | 16)   -- in bytes
+ * </pre>
+ *
+ * <p>Per DER, the {@code aes-ICVlen} field is omitted when it equals the
+ * DEFAULT (12 bytes / 96 bits) and present otherwise. The parameter spec
+ * surfaced via {@link #engineGetParameterSpec} is a {@link GCMParameterSpec}
+ * (tag length in bits + nonce) — the de-facto JCE AEAD parameter holder, which
+ * the {@link CCMCipherSpi} already accepts.
+ */
+public class CCMAlgorithmParameters
+    extends AlgorithmParametersSpi
+{
+    private static final int DEFAULT_ICV_BYTES = 12;
+    private static final int MIN_NONCE_LEN = 7;
+    private static final int MAX_NONCE_LEN = 13;
+
+    private byte[] nonce;
+    private int icvBytes;
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec paramSpec)
+        throws InvalidParameterSpecException
+    {
+        if (paramSpec instanceof GCMParameterSpec)
+        {
+            GCMParameterSpec spec = (GCMParameterSpec) paramSpec;
+            int tagBits = spec.getTLen();
+            if ((tagBits & 7) != 0)
+            {
+                throw new InvalidParameterSpecException("CCM tag length must be a multiple of 8 bits");
+            }
+            setNonceAndIcv(spec.getIV(), tagBits / 8);
+        }
+        else if (paramSpec instanceof IvParameterSpec)
+        {
+            // Nonce only — default the ICV length to the RFC 5084 DEFAULT.
+            setNonceAndIcv(((IvParameterSpec) paramSpec).getIV(), DEFAULT_ICV_BYTES);
+        }
+        else
+        {
+            throw new InvalidParameterSpecException(
+                    "CCM parameters require a GCMParameterSpec or IvParameterSpec, got "
+                            + (paramSpec == null ? "null" : paramSpec.getClass().getName()));
+        }
+    }
+
+    private void setNonceAndIcv(byte[] iv, int icv) throws InvalidParameterSpecException
+    {
+        if (iv == null)
+        {
+            throw new InvalidParameterSpecException("CCM nonce is null");
+        }
+        if (iv.length < MIN_NONCE_LEN || iv.length > MAX_NONCE_LEN)
+        {
+            throw new InvalidParameterSpecException(
+                    "CCM nonce must be " + MIN_NONCE_LEN + ".." + MAX_NONCE_LEN + " bytes (got " + iv.length + ")");
+        }
+        if (!isValidIcvLen(icv))
+        {
+            throw new InvalidParameterSpecException(
+                    "CCM ICV length must be 4, 6, 8, 10, 12, 14, or 16 bytes (got " + icv + ")");
+        }
+        this.nonce = Arrays.clone(iv);
+        this.icvBytes = icv;
+    }
+
+    @Override
+    protected void engineInit(byte[] params)
+        throws IOException
+    {
+        // CCMParameters ::= SEQUENCE { OCTET STRING nonce, INTEGER icvLen DEFAULT 12 }
+        if (params == null)
+        {
+            throw new IOException("null CCM parameters");
+        }
+        Reader r = new Reader(params);
+        Reader seq = r.readTLV(0x30, "CCMParameters SEQUENCE");
+        r.requireEnd("trailing bytes after CCMParameters");
+
+        byte[] readNonce = seq.readTLV(0x04, "aes-nonce OCTET STRING").remaining();
+        int readIcv = DEFAULT_ICV_BYTES;
+        if (!seq.atEnd())
+        {
+            byte[] icvEnc = seq.readTLV(0x02, "aes-ICVlen INTEGER").remaining();
+            readIcv = decodeIcvInteger(icvEnc);
+        }
+        seq.requireEnd("trailing bytes inside CCMParameters");
+
+        if (readNonce.length < MIN_NONCE_LEN || readNonce.length > MAX_NONCE_LEN)
+        {
+            throw new IOException("CCM nonce out of range: " + readNonce.length);
+        }
+        if (!isValidIcvLen(readIcv))
+        {
+            throw new IOException("CCM ICV length out of range: " + readIcv);
+        }
+        this.nonce = readNonce;
+        this.icvBytes = readIcv;
+    }
+
+    @Override
+    protected void engineInit(byte[] params, String format)
+        throws IOException
+    {
+        // RFC 5084 defines only the DER encoding; treat null/"ASN.1"/"DER" alike.
+        if (format == null || "ASN.1".equalsIgnoreCase(format) || "DER".equalsIgnoreCase(format))
+        {
+            engineInit(params);
+            return;
+        }
+        throw new IOException("unsupported CCM parameters format: " + format);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> paramSpec)
+        throws InvalidParameterSpecException
+    {
+        requireInitialised();
+        if (paramSpec == null)
+        {
+            throw new InvalidParameterSpecException("null parameter spec class");
+        }
+        if (paramSpec.isAssignableFrom(GCMParameterSpec.class))
+        {
+            return (T) new GCMParameterSpec(icvBytes * 8, Arrays.clone(nonce));
+        }
+        if (paramSpec.isAssignableFrom(IvParameterSpec.class))
+        {
+            return (T) new IvParameterSpec(Arrays.clone(nonce));
+        }
+        throw new InvalidParameterSpecException("unsupported parameter spec: " + paramSpec.getName());
+    }
+
+    @Override
+    protected byte[] engineGetEncoded()
+        throws IOException
+    {
+        requireInitialisedIO();
+        // Inner: OCTET STRING nonce [+ INTEGER icvLen when != DEFAULT].
+        byte[] octetString = tlv(0x04, nonce);
+        byte[] inner;
+        if (icvBytes == DEFAULT_ICV_BYTES)
+        {
+            inner = octetString;
+        }
+        else
+        {
+            byte[] integer = tlv(0x02, new byte[]{(byte) icvBytes});
+            inner = concat(octetString, integer);
+        }
+        return tlv(0x30, inner);
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format)
+        throws IOException
+    {
+        if (format == null || "ASN.1".equalsIgnoreCase(format) || "DER".equalsIgnoreCase(format))
+        {
+            return engineGetEncoded();
+        }
+        throw new IOException("unsupported CCM parameters format: " + format);
+    }
+
+    @Override
+    protected String engineToString()
+    {
+        if (nonce == null)
+        {
+            return "CCMParameters (uninitialised)";
+        }
+        return "CCMParameters [nonce=" + nonce.length + " bytes, icv=" + icvBytes + " bytes]";
+    }
+
+    private void requireInitialised() throws InvalidParameterSpecException
+    {
+        if (nonce == null)
+        {
+            throw new InvalidParameterSpecException("CCM parameters not initialised");
+        }
+    }
+
+    private void requireInitialisedIO() throws IOException
+    {
+        if (nonce == null)
+        {
+            throw new IOException("CCM parameters not initialised");
+        }
+    }
+
+    private static boolean isValidIcvLen(int icvBytes)
+    {
+        return icvBytes == 4 || icvBytes == 6 || icvBytes == 8 || icvBytes == 10
+                || icvBytes == 12 || icvBytes == 14 || icvBytes == 16;
+    }
+
+    /**
+     * Decode a minimally-encoded non-negative DER INTEGER (the ICV length is a
+     * small positive value, so it is one content byte with the top bit clear).
+     */
+    private static int decodeIcvInteger(byte[] content) throws IOException
+    {
+        if (content.length != 1 || (content[0] & 0x80) != 0)
+        {
+            throw new IOException("malformed CCM ICV length INTEGER");
+        }
+        return content[0] & 0xFF;
+    }
+
+    /** Encode a TLV with a single-byte definite length (content < 128 bytes). */
+    private static byte[] tlv(int tag, byte[] content)
+    {
+        // Every CCMParameters field is well under 128 bytes, so the length is a
+        // single octet — this codec deliberately does not handle longer forms.
+        byte[] out = new byte[2 + content.length];
+        out[0] = (byte) tag;
+        out[1] = (byte) content.length;
+        System.arraycopy(content, 0, out, 2, content.length);
+        return out;
+    }
+
+    private static byte[] concat(byte[] a, byte[] b)
+    {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    /**
+     * Minimal DER reader for the short-form (length &lt; 128) TLVs used by
+     * CCMParameters. Rejects long-form lengths and truncation.
+     */
+    private static final class Reader
+    {
+        private final byte[] buf;
+        private int pos;
+        private final int end;
+
+        Reader(byte[] buf)
+        {
+            this(buf, 0, buf.length);
+        }
+
+        Reader(byte[] buf, int off, int len)
+        {
+            this.buf = buf;
+            this.pos = off;
+            this.end = off + len;
+        }
+
+        boolean atEnd()
+        {
+            return pos >= end;
+        }
+
+        void requireEnd(String message) throws IOException
+        {
+            if (pos != end)
+            {
+                throw new IOException(message);
+            }
+        }
+
+        /** Read one TLV of the expected tag and return a Reader over its content. */
+        Reader readTLV(int expectedTag, String what) throws IOException
+        {
+            if (end - pos < 2)
+            {
+                throw new IOException("truncated " + what);
+            }
+            int tag = buf[pos++] & 0xFF;
+            if (tag != expectedTag)
+            {
+                throw new IOException("expected " + what + " (tag 0x"
+                        + Integer.toHexString(expectedTag) + "), got tag 0x" + Integer.toHexString(tag));
+            }
+            int len = buf[pos++] & 0xFF;
+            if ((len & 0x80) != 0)
+            {
+                throw new IOException("unsupported long-form length in " + what);
+            }
+            if (len > end - pos)
+            {
+                throw new IOException("truncated content in " + what);
+            }
+            Reader content = new Reader(buf, pos, len);
+            pos += len;
+            return content;
+        }
+
+        /** The remaining (content) bytes of this reader as a fresh array. */
+        byte[] remaining()
+        {
+            byte[] out = new byte[end - pos];
+            System.arraycopy(buf, pos, out, 0, out.length);
+            pos = end;
+            return out;
+        }
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CCMCipherSpi.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/CCMCipherSpi.java
@@ -196,11 +196,25 @@ public class CCMCipherSpi extends CipherSpi
     {
         int tagBits;
         byte[] nonce;
+        // Associated data carried by a BC AEADParameterSpec, buffered after init
+        // (see end of method). Null for the other spec types.
+        byte[] aeadAssociatedData = null;
         if (params instanceof GCMParameterSpec)
         {
             GCMParameterSpec spec = (GCMParameterSpec) params;
             tagBits = spec.getTLen();
             nonce = spec.getIV();
+        }
+        else if (AEADParameterSpecAccessor.matches(params))
+        {
+            // BC's AEADParameterSpec extends IvParameterSpec; unwrap it BEFORE the
+            // IvParameterSpec branch so its tag length and associated data are
+            // honoured rather than silently dropped (the dropped-AAD case yields
+            // a wrong-but-valid-looking tag and a bad-tag on decrypt).
+            AEADParameterSpecAccessor acc = AEADParameterSpecAccessor.extract(params);
+            tagBits = acc.getMacSizeInBits();
+            nonce = acc.getIV();
+            aeadAssociatedData = acc.getAssociatedData();
         }
         else if (params instanceof IvParameterSpec)
         {
@@ -279,6 +293,15 @@ public class CCMCipherSpi extends CipherSpi
         this.encryptionReinitRequired = false;
         this.aadBuffer.reset();
         this.dataBuffer.reset();
+
+        // Buffer any AEADParameterSpec-supplied associated data now (before any
+        // payload), concatenated at doFinal like AAD from engineUpdateAAD. Left
+        // with aadRejected == false so a caller may still append once via
+        // engineUpdateAAD, matching BouncyCastle's spec-AAD-then-updateAAD order.
+        if (aeadAssociatedData != null && aeadAssociatedData.length > 0)
+        {
+            this.aadBuffer.write(aeadAssociatedData, 0, aeadAssociatedData.length);
+        }
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/GCMAlgorithmParameters.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/blockcipher/GCMAlgorithmParameters.java
@@ -10,26 +10,33 @@
 
 package org.openssl.jostle.jcajce.provider.blockcipher;
 
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+
 import java.io.IOException;
 import java.security.AlgorithmParameters;
 import java.security.AlgorithmParametersSpi;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 
 /**
- * {@code AlgorithmParameters} for AES-GCM, registered under the AES-GCM OIDs so
- * that callers which resolve parameters by OID (notably the CMS EnvelopedData
- * decryption path, which does {@code AlgorithmParameters.getInstance(<aes-gcm-oid>, "JSL")}
- * then loads the stored {@code GCMParameters} to recover the nonce/ICV length)
- * can obtain a working instance from this provider. The ASN.1 codec and the
- * {@code GCMParameterSpec} translation are delegated to the JDK's own "GCM"
- * {@code AlgorithmParameters}.
- * <p>
- * Deliberately NOT registered under the bare name "GCM": the delegate is looked
- * up via {@code AlgorithmParameters.getInstance("GCM")} (no provider), so
- * claiming that name here could resolve back to this class and recurse. Resolving
- * only by OID keeps the delegate pointing at the JDK provider.
+ * {@code AlgorithmParameters} for AES-GCM, registered under the bare name
+ * {@code "GCM"} and the AES-GCM OIDs so callers can resolve GCM parameters from
+ * this provider either way — by OID (notably the CMS EnvelopedData decryption
+ * path, {@code AlgorithmParameters.getInstance(<aes-gcm-oid>, "JSL")}, recovering
+ * the stored nonce/ICV length) or by name (a JSL-bound helper doing
+ * {@code helper.createAlgorithmParameters("GCM")}). The ASN.1 codec and the
+ * {@code GCMParameterSpec} translation are delegated to a platform GCM
+ * {@code AlgorithmParameters} (SunJCE on a standard JDK).
+ *
+ * <p>Because this IS registered under the bare name {@code "GCM"}, the delegate
+ * must be resolved from a provider that is NOT Jostle, or
+ * {@code getInstance("GCM")} could route back into this class and recurse.
+ * {@link #resolveDelegate()} walks the installed providers and skips Jostle for
+ * exactly that reason — the same approach as
+ * {@link org.openssl.jostle.jcajce.provider.ec.ECAlgorithmParameters}.
  */
 public class GCMAlgorithmParameters
     extends AlgorithmParametersSpi
@@ -38,14 +45,37 @@ public class GCMAlgorithmParameters
 
     public GCMAlgorithmParameters()
     {
-        try
+        this.delegate = resolveDelegate();
+    }
+
+    /**
+     * Find a platform GCM {@code AlgorithmParameters} that is not this
+     * provider's, so delegation cannot recurse into this class.
+     */
+    private static AlgorithmParameters resolveDelegate()
+    {
+        for (Provider p : Security.getProviders())
         {
-            this.delegate = AlgorithmParameters.getInstance("GCM");
+            if (JostleProvider.PROVIDER_NAME.equals(p.getName()))
+            {
+                continue;
+            }
+            if (p.getService("AlgorithmParameters", "GCM") == null)
+            {
+                continue;
+            }
+            try
+            {
+                return AlgorithmParameters.getInstance("GCM", p);
+            }
+            catch (NoSuchAlgorithmException e)
+            {
+                // Service advertised but not constructible from this
+                // provider — keep looking.
+            }
         }
-        catch (NoSuchAlgorithmException e)
-        {
-            throw new IllegalStateException("no GCM AlgorithmParameters available from the platform", e);
-        }
+        throw new IllegalStateException(
+                "no non-Jostle AlgorithmParameters(\"GCM\") available from the platform");
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/HKDFSecretKeyFactory.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/HKDFSecretKeyFactory.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License"). You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+package org.openssl.jostle.jcajce.provider.kdf;
+
+import org.openssl.jostle.jcajce.provider.NISelector;
+import org.openssl.jostle.jcajce.spec.HKDFParameterSpec;
+import org.openssl.jostle.jcajce.util.DigestUtil;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactorySpi;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+/**
+ * {@code SecretKeyFactory} surface for HKDF (RFC 5869), backed by the native
+ * {@code EVP_KDF "HKDF"} (extract-and-expand) via {@link KdfNI#hkdf}. The digest
+ * is fixed per registered algorithm ("HKDF-SHA256" / "HKDF-SHA384" / "HKDF-SHA512");
+ * the {@link HKDFParameterSpec} supplies the IKM, optional salt, optional info and
+ * the desired output length (in bytes).
+ */
+public class HKDFSecretKeyFactory extends SecretKeyFactorySpi
+{
+    private final String digestAlgorithm;
+
+    public HKDFSecretKeyFactory(String digestAlgorithm)
+    {
+        this.digestAlgorithm = DigestUtil.getCanonicalDigestName(digestAlgorithm);
+    }
+
+    @Override
+    protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException
+    {
+        byte[] ikm;
+        byte[] salt;
+        byte[] info;
+        int outputLength;
+
+        if (keySpec instanceof HKDFParameterSpec)
+        {
+            HKDFParameterSpec spec = (HKDFParameterSpec) keySpec;
+            ikm = spec.getIKM();
+            salt = spec.getSalt();
+            info = spec.getInfo();
+            outputLength = spec.getOutputLength();
+        }
+        else if (keySpec != null)
+        {
+            // Accept any structurally-compatible HKDFParameterSpec (notably BouncyCastle's
+            // org.bouncycastle.jcajce.spec.HKDFParameterSpec) without a compile-time dependency on
+            // it, so high-level CMS/OpenPGP builders that construct that type can derive through this
+            // native HKDF. Same accessor contract (getIKM/getSalt/getInfo/getOutputLength), same units
+            // (output length in bytes). A spec missing any accessor surfaces as InvalidKeySpecException.
+            Class<?> cls = keySpec.getClass();
+            try
+            {
+                ikm = (byte[]) cls.getMethod("getIKM").invoke(keySpec);
+                salt = (byte[]) cls.getMethod("getSalt").invoke(keySpec);
+                info = (byte[]) cls.getMethod("getInfo").invoke(keySpec);
+                outputLength = (Integer) cls.getMethod("getOutputLength").invoke(keySpec);
+            }
+            catch (ReflectiveOperationException | ClassCastException | NullPointerException e)
+            {
+                throw new InvalidKeySpecException("unsupported KeySpec " + cls.getName(), e);
+            }
+        }
+        else
+        {
+            throw new InvalidKeySpecException("unsupported KeySpec null");
+        }
+
+        if (outputLength <= 0)
+        {
+            throw new InvalidKeySpecException("output length must be positive");
+        }
+
+        byte[] rawKey = new byte[outputLength];
+
+        NISelector.KdfNI.handleErrorCodes(NISelector.KdfNI.hkdf(
+                ikm,
+                salt,
+                info,
+                digestAlgorithm,
+                rawKey, 0, rawKey.length));
+
+        return new SecretKeySpec(rawKey, "HKDF");
+    }
+
+    @Override
+    protected KeySpec engineGetKeySpec(SecretKey key, Class<?> keySpec) throws InvalidKeySpecException
+    {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    protected SecretKey engineTranslateKey(SecretKey key) throws InvalidKeyException
+    {
+        throw new InvalidKeyException("not implemented");
+    }
+}

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOScryptKey.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/JOScryptKey.java
@@ -14,6 +14,7 @@ package org.openssl.jostle.jcajce.provider.kdf;
 import org.openssl.jostle.util.Arrays;
 
 import javax.crypto.SecretKey;
+import javax.crypto.interfaces.PBEKey;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 import java.io.Serializable;
@@ -22,7 +23,7 @@ import java.security.spec.KeySpec;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-class JOScryptKey implements KeySpec, SecretKey, Destroyable, Serializable
+class JOScryptKey implements KeySpec, PBEKey, Destroyable, Serializable
 {
     private final AtomicBoolean hasBeenDestroyed = new AtomicBoolean(false);
     private static final long serialVersionUID = 658060872465898190L;
@@ -82,6 +83,21 @@ class JOScryptKey implements KeySpec, SecretKey, Destroyable, Serializable
     {
         checkDestroyed(this);
         return p;
+    }
+
+    /**
+     * PBEKey contract. scrypt has no PBKDF-style iteration count; the closest
+     * analogue is the CPU/memory cost parameter N (also available, unambiguously,
+     * via {@link #getCostParameter()}). Implementing {@link PBEKey} marks this as
+     * password-derived key material so a block cipher accepts it directly in a
+     * PBES2 flow; the value is informational — the raw key bytes are already
+     * derived and used via {@link #getEncoded()}.
+     */
+    @Override
+    public int getIterationCount()
+    {
+        checkDestroyed(this);
+        return n;
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/KdfNI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/KdfNI.java
@@ -19,6 +19,8 @@ public interface KdfNI extends DefaultServiceNI
 
     int pbkdf2(byte[] password, byte[] salt, int iter, String digest, byte[] out, int outOffset, int outLen);
 
+    int hkdf(byte[] ikm, byte[] salt, byte[] info, String digest, byte[] out, int outOffset, int outLen);
+
     default long handleErrorCodes(int code)
     {
         if (code >= 0)
@@ -50,6 +52,12 @@ public interface KdfNI extends DefaultServiceNI
                 throw new IllegalArgumentException("r is negative");
             case JO_KDF_SCRYPT_P_NEGATIVE:
                 throw new IllegalArgumentException("p is negative");
+            case JO_KDF_HKDF_IKM_NULL:
+                throw new IllegalArgumentException("ikm is null");
+            case JO_KDF_HKDF_IKM_FAILED_ACCESS:
+                throw new AccessException("unable to access ikm array");
+            case JO_KDF_HKDF_INFO_FAILED_ACCESS:
+                throw new AccessException("unable to access info array");
             default:
         }
         return baseErrorHandler(code);

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/KdfNIJNI.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/KdfNIJNI.java
@@ -18,5 +18,8 @@ public class KdfNIJNI implements KdfNI
 
     @Override
     public native int pbkdf2(byte[] password, byte[] salt, int iter, String digest, byte[] out, int outOffset, int outLen);
+
+    @Override
+    public native int hkdf(byte[] ikm, byte[] salt, byte[] info, String digest, byte[] out, int outOffset, int outLen);
 }
 

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/ScryptSecretKeyFactory.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/provider/kdf/ScryptSecretKeyFactory.java
@@ -22,40 +22,62 @@ import java.security.spec.KeySpec;
 
 public class ScryptSecretKeyFactory extends SecretKeyFactorySpi
 {
-
-
-    public ScryptSecretKeyFactory()
-    {
-
-    }
-
-
     @Override
     protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException
     {
+        char[] password;
+        byte[] salt;
+        int costParameter, blockSize, parallelizationParameter, keyLengthBits;
+
         if (keySpec instanceof ScryptKeySpec)
         {
             ScryptKeySpec spec = (ScryptKeySpec) keySpec;
-
-            byte[] rawKey = new byte[spec.getKeyLength() >> 3];
-
-
-            NISelector.KdfNI.handleErrorCodes(NISelector.KdfNI.scrypt(
-                    Strings.toUTF8ByteArray(spec.getPassword()),
-                    spec.getSalt(),
-                    spec.getCostParameter(),
-                    spec.getBlockSize(),
-                    spec.getParallelizationParameter(),
-                    rawKey, 0, rawKey.length));
-
-
-            String name = "ScryptWithUTF8";
-
-            return new JOScryptKey(name, spec.getPassword(), spec.getSalt(), spec.getCostParameter(), spec.getBlockSize(), spec.getParallelizationParameter(), rawKey);
-
+            password = spec.getPassword();
+            salt = spec.getSalt();
+            costParameter = spec.getCostParameter();
+            blockSize = spec.getBlockSize();
+            parallelizationParameter = spec.getParallelizationParameter();
+            keyLengthBits = spec.getKeyLength();
+        }
+        else if (keySpec != null)
+        {
+            // Accept any structurally-compatible ScryptKeySpec (notably BouncyCastle's
+            // org.bouncycastle.jcajce.spec.ScryptKeySpec) without a compile-time dependency
+            // on it, so high-level PBES2/PKCS#8/PKCS#12 builders that construct that type can
+            // derive keys through this native scrypt KDF. Same accessor contract, same units
+            // (keyLength in bits); the password is UTF-8 encoded below either way. A spec
+            // missing any accessor surfaces as InvalidKeySpecException from the reflective call.
+            Class<?> cls = keySpec.getClass();
+            try
+            {
+                password = (char[]) cls.getMethod("getPassword").invoke(keySpec);
+                salt = (byte[]) cls.getMethod("getSalt").invoke(keySpec);
+                costParameter = (Integer) cls.getMethod("getCostParameter").invoke(keySpec);
+                blockSize = (Integer) cls.getMethod("getBlockSize").invoke(keySpec);
+                parallelizationParameter = (Integer) cls.getMethod("getParallelizationParameter").invoke(keySpec);
+                keyLengthBits = (Integer) cls.getMethod("getKeyLength").invoke(keySpec);
+            }
+            catch (ReflectiveOperationException | ClassCastException | NullPointerException e)
+            {
+                throw new InvalidKeySpecException("unsupported KeySpec " + cls.getName(), e);
+            }
+        }
+        else
+        {
+            throw new InvalidKeySpecException("unsupported KeySpec null");
         }
 
-        throw new InvalidKeySpecException("unsupported KeySpec " + keySpec.getClass().getName());
+        byte[] rawKey = new byte[keyLengthBits >> 3];
+
+        NISelector.KdfNI.handleErrorCodes(NISelector.KdfNI.scrypt(
+                Strings.toUTF8ByteArray(password),
+                salt,
+                costParameter,
+                blockSize,
+                parallelizationParameter,
+                rawKey, 0, rawKey.length));
+
+        return new JOScryptKey("ScryptWithUTF8", password, salt, costParameter, blockSize, parallelizationParameter, rawKey);
     }
 
     @Override

--- a/jostle/src/main/java/org/openssl/jostle/jcajce/spec/HKDFParameterSpec.java
+++ b/jostle/src/main/java/org/openssl/jostle/jcajce/spec/HKDFParameterSpec.java
@@ -1,0 +1,78 @@
+package org.openssl.jostle.jcajce.spec;
+
+import org.openssl.jostle.util.Arrays;
+
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.KeySpec;
+
+public class HKDFParameterSpec
+    implements KeySpec, AlgorithmParameterSpec
+{
+    private final byte[] ikm;
+    private final byte[] salt;
+    private final byte[] info;
+    private final int outputLength;
+
+    public HKDFParameterSpec(byte[] ikm, byte[] salt, byte[] info, int outputLength)
+    {
+        // Field normalisation matches the previous BouncyCastle HKDFParameters
+        // behaviour: the IKM is copied; an absent or empty salt is stored as
+        // null (HKDF-Extract then uses a HashLen-zero salt); an absent info is
+        // stored as an empty array so getInfo() is never null.
+        this.ikm = Arrays.clone(ikm);
+        this.salt = (salt == null || salt.length == 0) ? null : Arrays.clone(salt);
+        this.info = (info == null) ? new byte[0] : Arrays.clone(info);
+        this.outputLength = outputLength;
+    }
+
+    /**
+     * Returns the input keying material or seed.
+     *
+     * @return the keying material
+     */
+    public byte[] getIKM()
+    {
+        return Arrays.clone(ikm);
+    }
+
+    /**
+     * Returns if step 1: extract has to be skipped or not
+     *
+     * @return true for skipping, false for no skipping of step 1
+     */
+    public boolean skipExtract()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the salt, or null if the salt should be generated as a byte array
+     * of HashLen zeros.
+     *
+     * @return the salt, or null
+     */
+    public byte[] getSalt()
+    {
+        return Arrays.clone(salt);
+    }
+
+    /**
+     * Returns the info field, which may be empty (null is converted to empty).
+     *
+     * @return the info field, never null
+     */
+    public byte[] getInfo()
+    {
+        return Arrays.clone(info);
+    }
+
+    /**
+     * Returns the length (in bytes) of the output resulting from these parameters.
+     *
+     * @return output length, in bytes.
+     */
+    public int getOutputLength()
+    {
+        return outputLength;
+    }
+}

--- a/jostle/src/main/java25/org/openssl/jostle/jcajce/provider/kdf/KdfNIFFI.java
+++ b/jostle/src/main/java25/org/openssl/jostle/jcajce/provider/kdf/KdfNIFFI.java
@@ -30,6 +30,9 @@ public class KdfNIFFI implements KdfNI
     private static final MemorySegment scrypt;
     private static final MethodHandle scryptFuncHandle;
 
+    private static final MemorySegment hkdf;
+    private static final MethodHandle hkdfFuncHandle;
+
     static
     {
 
@@ -62,6 +65,25 @@ public class KdfNIFFI implements KdfNI
                         ValueLayout.JAVA_INT, // n
                         ValueLayout.JAVA_INT, // r
                         ValueLayout.JAVA_INT, // p
+                        ValueLayout.ADDRESS, // output
+                        ValueLayout.JAVA_LONG, // output_size -- total length of output array
+                        ValueLayout.JAVA_INT, // output offset
+                        ValueLayout.JAVA_INT // output length wanted
+                ), Linker.Option.critical(true));
+
+
+        hkdf = lookup.find("KDF_HKDF").orElseThrow();
+        hkdfFuncHandle = linker.downcallHandle(hkdf,
+                FunctionDescriptor.of(
+                        ValueLayout.JAVA_INT, // return value
+                        ValueLayout.ADDRESS, // ikm
+                        ValueLayout.JAVA_LONG, // ikm_len
+                        ValueLayout.ADDRESS, // salt
+                        ValueLayout.JAVA_LONG, // salt_len
+                        ValueLayout.ADDRESS, // info
+                        ValueLayout.JAVA_LONG, // info_len
+                        ValueLayout.ADDRESS, // digest name as bytes
+                        ValueLayout.JAVA_LONG, // length of digest name + null terminus
                         ValueLayout.ADDRESS, // output
                         ValueLayout.JAVA_LONG, // output_size -- total length of output array
                         ValueLayout.JAVA_INT, // output offset
@@ -130,6 +152,38 @@ public class KdfNIFFI implements KdfNI
         {
             L.log(Level.WARNING,
                     "FFI KDF_PBKDF2", t);
+            throw new RuntimeException(t.getMessage(), t);
+        }
+    }
+
+    @Override
+    public int hkdf(byte[] ikm, byte[] salt, byte[] info, String digest, byte[] out, int outOffset, int outLen)
+    {
+        try (Arena a = Arena.ofConfined())
+        {
+            MemorySegment ikmSeg = (ikm == null) ? MemorySegment.NULL : MemorySegment.ofArray(ikm);
+            MemorySegment saltSeg = (salt == null) ? MemorySegment.NULL : MemorySegment.ofArray(salt);
+            MemorySegment infoSeg = (info == null) ? MemorySegment.NULL : MemorySegment.ofArray(info);
+            MemorySegment digestName = (digest == null) ? MemorySegment.NULL : a.allocateFrom(digest);
+            MemorySegment output = (out == null) ? MemorySegment.NULL : MemorySegment.ofArray(out);
+
+            return (int) hkdfFuncHandle.invokeExact(
+                    ikmSeg, ikmSeg.byteSize(),
+                    saltSeg, saltSeg.byteSize(),
+                    infoSeg, infoSeg.byteSize(),
+                    digestName,
+                    digest == null ? 0L : digestName.byteSize() - 1, // less null terminus
+                    output,
+                    output.byteSize(),
+                    outOffset,
+                    outLen
+            );
+
+        }
+        catch (Throwable t)
+        {
+            L.log(Level.WARNING,
+                    "FFI KDF_HKDF", t);
             throw new RuntimeException(t.getMessage(), t);
         }
     }

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -245,8 +245,12 @@ class BlockCipherSpi extends CipherSpi
             try
             {
                 AlgorithmParameters params;
-                if (osslMode == OSSLMode.GCM)
+                if (isAeadMode())
                 {
+                    // GCM AlgorithmParameters is the de-facto JCE holder for any
+                    // AEAD tag+nonce; OCB has no JCE-standard parameters type, so
+                    // it reuses GCM's. The tag length is preserved on round-trip
+                    // (a plain IvParameterSpec would drop it).
                     params = AlgorithmParameters.getInstance("GCM");
                     params.init(new GCMParameterSpec(tagLen * 8, ivBytes));
                 }
@@ -317,7 +321,7 @@ class BlockCipherSpi extends CipherSpi
                     iv = new byte[ivLen];
                     SecureRandom rng = (random != null) ? random : CryptoServicesRegistrar.getSecureRandom();
                     rng.nextBytes(iv);
-                    tag = (osslMode == OSSLMode.GCM) ? 16 : 0;
+                    tag = isAeadMode() ? 16 : 0;
                 }
                 else
                 {
@@ -330,14 +334,7 @@ class BlockCipherSpi extends CipherSpi
                 if (params instanceof IvParameterSpec)
                 {
                     iv = ((IvParameterSpec) params).getIV();
-                    if (osslMode == OSSLMode.GCM)
-                    {
-                        tag = 16;
-                    }
-                    else
-                    {
-                        tag = 0;
-                    }
+                    tag = isAeadMode() ? 16 : 0;
                 }
                 else
                 {
@@ -411,6 +408,20 @@ class BlockCipherSpi extends CipherSpi
         default:
             return engineGetBlockSize();
         }
+    }
+
+    /**
+     * True for the AEAD modes this SPI drives (GCM and OCB). Both append an
+     * authentication tag and default to a 16-byte tag when the caller doesn't
+     * specify one via a {@link GCMParameterSpec}. CCM is handled by a dedicated
+     * SPI and is not seen here. The default-16 applies to OCB as well as GCM:
+     * leaving OCB's tag length at 0 left OpenSSL's OCB cipher with no tag length
+     * established, which surfaced as {@code aes_ocb_get_ctx_params: invalid tag
+     * length} at the {@code EVP_CTRL_AEAD_GET_TAG} step on encrypt.
+     */
+    private boolean isAeadMode()
+    {
+        return osslMode == OSSLMode.GCM || osslMode == OSSLMode.OCB;
     }
 
 

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -19,6 +19,7 @@ import org.openssl.jostle.util.Arrays;
 import org.openssl.jostle.util.Strings;
 
 import javax.crypto.*;
+import javax.crypto.interfaces.PBEKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -892,6 +893,18 @@ class BlockCipherSpi extends CipherSpi
 
     protected void validateKeyAlg(Key key) throws InvalidKeyException
     {
+        // A password/KDF-derived key (PBKDF2 or scrypt — a javax.crypto PBEKey)
+        // is generic RAW key material whose owning algorithm is the PBES2 /
+        // PKCS#8 EncryptionScheme, not a competing cipher; accept it for any
+        // cipher (the native layer still validates the key length). A key
+        // explicitly tagged for a different cipher family — e.g. an "ARIA"
+        // SecretKeySpec on an AES cipher — is not a PBEKey and is still rejected
+        // by the name check below.
+        if (key instanceof PBEKey)
+        {
+            return;
+        }
+
         String alg = key.getAlgorithm();
         if (alg != null)
         {

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/BlockCipherSpi.java
@@ -300,6 +300,9 @@ class BlockCipherSpi extends CipherSpi
             ensureNativeReference();
             final byte[] iv;
             final int tag;
+            // Associated data carried by a BC AEADParameterSpec, fed to the
+            // native layer after a successful init (see below). Null otherwise.
+            byte[] aeadAssociatedData = null;
             blockSize = 0;
             // The native layer only knows ENCRYPT/DECRYPT. WRAP/UNWRAP (used for
             // key-wrap modes) map onto encrypt/decrypt respectively.
@@ -329,35 +332,46 @@ class BlockCipherSpi extends CipherSpi
                     tag = 0;
                 }
             }
+            else if (isAeadMode() && AEADParameterSpecAccessor.matches(params))
+            {
+                // BC's AEADParameterSpec extends IvParameterSpec; unwrap it here,
+                // BEFORE the IvParameterSpec branch, so its tag length and
+                // associated data are honoured rather than silently dropped (the
+                // dropped-AAD case produces a wrong-but-valid-looking tag).
+                AEADParameterSpecAccessor acc = AEADParameterSpecAccessor.extract(params);
+                int tLen = acc.getMacSizeInBits();
+                if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
+                {
+                    throw new InvalidAlgorithmParameterException(
+                            "AEAD tag length must be 32 to 128 bits and a multiple of 8");
+                }
+                iv = acc.getIV();
+                tag = tLen / 8;
+                aeadAssociatedData = acc.getAssociatedData();
+            }
+            else if (params instanceof IvParameterSpec)
+            {
+                iv = ((IvParameterSpec) params).getIV();
+                tag = isAeadMode() ? 16 : 0;
+            }
+            else if (params instanceof GCMParameterSpec)
+            {
+                int tLen = ((GCMParameterSpec) params).getTLen();
+                // Reject malformed AEAD tag lengths at the JCE boundary —
+                // BouncyCastle's 32–128-bit, multiple-of-8 range, which the
+                // cross-provider agreement tests rely on — rather than
+                // passing an out-of-spec length down to OpenSSL.
+                if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
+                {
+                    throw new InvalidAlgorithmParameterException(
+                            "AEAD tag length must be 32 to 128 bits and a multiple of 8");
+                }
+                iv = ((GCMParameterSpec) params).getIV();
+                tag = tLen / 8;
+            }
             else
             {
-                if (params instanceof IvParameterSpec)
-                {
-                    iv = ((IvParameterSpec) params).getIV();
-                    tag = isAeadMode() ? 16 : 0;
-                }
-                else
-                {
-                    if (params instanceof GCMParameterSpec)
-                    {
-                        int tLen = ((GCMParameterSpec) params).getTLen();
-                        // Reject malformed AEAD tag lengths at the JCE boundary —
-                        // BouncyCastle's 32–128-bit, multiple-of-8 range, which the
-                        // cross-provider agreement tests rely on — rather than
-                        // passing an out-of-spec length down to OpenSSL.
-                        if (tLen < 32 || tLen > 128 || (tLen & 7) != 0)
-                        {
-                            throw new InvalidAlgorithmParameterException(
-                                    "AEAD tag length must be 32 to 128 bits and a multiple of 8");
-                        }
-                        iv = ((GCMParameterSpec) params).getIV();
-                        tag = tLen / 8;
-                    }
-                    else
-                    {
-                        throw new InvalidAlgorithmParameterException("unsupported parameter spec: " + params);
-                    }
-                }
+                throw new InvalidAlgorithmParameterException("unsupported parameter spec: " + params);
             }
 
             this.ivBytes = iv;
@@ -378,6 +392,15 @@ class BlockCipherSpi extends CipherSpi
                 {
                     Arrays.fill(keyBytes, (byte) 0);
                 }
+            }
+
+            // Init succeeded: feed any AEADParameterSpec-supplied associated data
+            // now — after init, before any plaintext — so it's authenticated.
+            // This is the same native call engineUpdateAAD makes; the reuse guard
+            // is unnecessary here because the cipher was just (re)initialised.
+            if (aeadAssociatedData != null && aeadAssociatedData.length > 0)
+            {
+                blockCipherNi.updateAAD(refWrapper.getReference(), aeadAssociatedData, 0, aeadAssociatedData.length);
             }
 
             engineGetBlockSize();

--- a/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/CCMCipherSpi.java
+++ b/jostle/src/main/java9/org/openssl/jostle/jcajce/provider/blockcipher/CCMCipherSpi.java
@@ -179,11 +179,25 @@ public class CCMCipherSpi extends CipherSpi
     {
         int tagBits;
         byte[] nonce;
+        // Associated data carried by a BC AEADParameterSpec, buffered after init
+        // (see end of method). Null for the other spec types.
+        byte[] aeadAssociatedData = null;
         if (params instanceof GCMParameterSpec)
         {
             GCMParameterSpec spec = (GCMParameterSpec) params;
             tagBits = spec.getTLen();
             nonce = spec.getIV();
+        }
+        else if (AEADParameterSpecAccessor.matches(params))
+        {
+            // BC's AEADParameterSpec extends IvParameterSpec; unwrap it BEFORE the
+            // IvParameterSpec branch so its tag length and associated data are
+            // honoured rather than silently dropped (the dropped-AAD case yields
+            // a wrong-but-valid-looking tag and a bad-tag on decrypt).
+            AEADParameterSpecAccessor acc = AEADParameterSpecAccessor.extract(params);
+            tagBits = acc.getMacSizeInBits();
+            nonce = acc.getIV();
+            aeadAssociatedData = acc.getAssociatedData();
         }
         else if (params instanceof IvParameterSpec)
         {
@@ -266,6 +280,15 @@ public class CCMCipherSpi extends CipherSpi
         this.encryptionReinitRequired = false;
         this.aadBuffer.reset();
         this.dataBuffer.reset();
+
+        // Buffer any AEADParameterSpec-supplied associated data now (before any
+        // payload), concatenated at doFinal like AAD from engineUpdateAAD. Left
+        // with aadRejected == false so a caller may still append once via
+        // engineUpdateAAD, matching BouncyCastle's spec-AAD-then-updateAAD order.
+        if (aeadAssociatedData != null && aeadAssociatedData.length > 0)
+        {
+            this.aadBuffer.write(aeadAssociatedData, 0, aeadAssociatedData.length);
+        }
     }
 
     @Override

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESAgreementTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESAgreementTest.java
@@ -1783,6 +1783,62 @@ public class AESAgreementTest
         return enc.doFinal(msg);
     }
 
+    /**
+     * Reuse a single JSL GCM {@code Cipher} instance across several chunks, each
+     * with its own nonce (the OpenPGP SEIPDv2 / RFC 9580 per-chunk pattern:
+     * re-init → updateAAD → doFinal, repeated). Every chunk must agree byte-for-byte
+     * with a fresh BouncyCastle GCM cipher on the same inputs, proving the re-init
+     * path resets the AEAD state (no nonce/AAD/tag carry-over between chunks). This
+     * is the JSL-side half of the OpenPGP GCM chunked-mode investigation in
+     * docs/PGP_AEAD_CIPHER_GAP.md — it isolates whether the bc-jostle-libs "bad tag"
+     * failure is a JSL GCM re-init bug (it is not) or lives in the consumer framing.
+     */
+    @Test
+    public void aesGCM_reInitWithSuccessiveNonces_agreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("aesGCM_reInitWithSuccessiveNonces_agreesWithBC");
+        String xform = "AES/GCM/NoPadding";
+        byte[] key = new byte[32];
+        sr.nextBytes(key);
+        SecretKey secretKey = new SecretKeySpec(key, "AES");
+        byte[] baseIv = new byte[12];
+        sr.nextBytes(baseIv);
+
+        // One JSL cipher instance, re-initialised per chunk.
+        Cipher jostleEnc = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+
+        for (int chunk = 0; chunk < 6; chunk++)
+        {
+            // Per-chunk nonce: low byte of the base IV XOR chunk index.
+            byte[] iv = baseIv.clone();
+            iv[iv.length - 1] ^= (byte) chunk;
+            GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+
+            byte[] aad = new byte[sr.nextInt(40)];
+            sr.nextBytes(aad);
+            byte[] msg = new byte[1 + sr.nextInt(256)];
+            sr.nextBytes(msg);
+
+            jostleEnc.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+            jostleEnc.updateAAD(aad);
+            byte[] jostleCT = jostleEnc.doFinal(msg);
+
+            Cipher bcEnc = Cipher.getInstance(xform, BouncyCastleProvider.PROVIDER_NAME);
+            bcEnc.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+            bcEnc.updateAAD(aad);
+            byte[] bcCT = bcEnc.doFinal(msg);
+
+            Assertions.assertArrayEquals(bcCT, jostleCT,
+                    "chunk=" + chunk + ": re-init GCM ciphertext+tag diverged from BC");
+
+            // And the reused instance must still decrypt correctly.
+            jostleEnc.init(Cipher.DECRYPT_MODE, secretKey, spec);
+            jostleEnc.updateAAD(aad);
+            Assertions.assertArrayEquals(msg, jostleEnc.doFinal(jostleCT),
+                    "chunk=" + chunk + ": re-init GCM roundtrip failed");
+        }
+    }
+
 
     // -----------------------------------------------------------------
     // AES-OCB (AEAD, RFC 7253) — agreement with BouncyCastle, tag-length
@@ -2012,6 +2068,94 @@ public class AESAgreementTest
             Assertions.fail("AES-OCB must reject tampered AAD");
         }
         catch (AEADBadTagException expected) { }
+    }
+
+    /**
+     * OCB initialised with a plain {@link IvParameterSpec} (no tag length
+     * supplied) must default to a 128-bit tag and agree byte-for-byte with
+     * BouncyCastle's OCB on the same path. This is the path that was broken:
+     * OCB defaulted its tag length to 0 (only GCM defaulted to 16), leaving
+     * OpenSSL's OCB cipher with no tag length and failing at GET_TAG with
+     * {@code aes_ocb_get_ctx_params: invalid tag length}.
+     */
+    @Test
+    public void aesOCB_ivParameterSpec_agreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("aesOCB_ivParameterSpec_agreesWithBC");
+        String xform = "AES/OCB/NoPadding";
+        for (int trial = 0; trial < 10; trial++)
+        {
+            byte[] key = new byte[32];
+            sr.nextBytes(key);
+            byte[] iv = new byte[12];
+            sr.nextBytes(iv);
+            byte[] aad = new byte[sr.nextInt(48)];
+            sr.nextBytes(aad);
+            byte[] msg = new byte[1 + sr.nextInt(256)];
+            sr.nextBytes(msg);
+
+            SecretKey secretKey = new SecretKeySpec(key, "AES");
+            IvParameterSpec spec = new IvParameterSpec(iv);
+
+            Cipher bcEnc = Cipher.getInstance(xform, BouncyCastleProvider.PROVIDER_NAME);
+            bcEnc.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+            bcEnc.updateAAD(aad);
+            byte[] bcCT = bcEnc.doFinal(msg);
+
+            Cipher jostleEnc = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            jostleEnc.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+            jostleEnc.updateAAD(aad);
+            byte[] jostleCT = jostleEnc.doFinal(msg);
+
+            Assertions.assertArrayEquals(bcCT, jostleCT,
+                    "trial=" + trial + ": AES-OCB (IvParameterSpec) ciphertext+tag diverged from BC");
+
+            Cipher jostleDec = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            jostleDec.init(Cipher.DECRYPT_MODE, secretKey, spec);
+            jostleDec.updateAAD(aad);
+            Assertions.assertArrayEquals(msg, jostleDec.doFinal(jostleCT),
+                    "trial=" + trial + ": AES-OCB (IvParameterSpec) roundtrip failed");
+        }
+    }
+
+    /**
+     * OCB with no parameters at all: the SPI must auto-generate the nonce and
+     * default the tag to 128 bits (the same contract GCM already honoured), then
+     * round-trip through the parameters it exposes via {@code engineGetParameters}.
+     * Proves the tag-default fix on the no-spec path without depending on BC's
+     * default.
+     */
+    @Test
+    public void aesOCB_noParams_roundTripsThroughExposedParameters() throws Exception
+    {
+        SecureRandom sr = seededRandom("aesOCB_noParams_roundTripsThroughExposedParameters");
+        String xform = "AES/OCB/NoPadding";
+        for (int trial = 0; trial < 10; trial++)
+        {
+            byte[] key = new byte[32];
+            sr.nextBytes(key);
+            byte[] aad = new byte[sr.nextInt(48)];
+            sr.nextBytes(aad);
+            byte[] msg = new byte[1 + sr.nextInt(256)];
+            sr.nextBytes(msg);
+
+            SecretKey secretKey = new SecretKeySpec(key, "AES");
+
+            Cipher enc = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            enc.init(Cipher.ENCRYPT_MODE, secretKey);
+            enc.updateAAD(aad);
+            byte[] ct = enc.doFinal(msg);
+
+            // The SPI must have generated a nonce and exposed the AEAD parameters.
+            java.security.AlgorithmParameters params = enc.getParameters();
+            Assertions.assertNotNull(params, "trial=" + trial + ": OCB must expose generated parameters");
+
+            Cipher dec = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            dec.init(Cipher.DECRYPT_MODE, secretKey, params);
+            dec.updateAAD(aad);
+            Assertions.assertArrayEquals(msg, dec.doFinal(ct),
+                    "trial=" + trial + ": AES-OCB no-params roundtrip failed");
+        }
     }
 
 

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESAgreementTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESAgreementTest.java
@@ -1810,7 +1810,7 @@ public class AESAgreementTest
         for (int chunk = 0; chunk < 6; chunk++)
         {
             // Per-chunk nonce: low byte of the base IV XOR chunk index.
-            byte[] iv = baseIv.clone();
+            byte[] iv = Arrays.clone(baseIv);
             iv[iv.length - 1] ^= (byte) chunk;
             GCMParameterSpec spec = new GCMParameterSpec(128, iv);
 
@@ -2155,6 +2155,78 @@ public class AESAgreementTest
             dec.updateAAD(aad);
             Assertions.assertArrayEquals(msg, dec.doFinal(ct),
                     "trial=" + trial + ": AES-OCB no-params roundtrip failed");
+        }
+    }
+
+    /**
+     * BouncyCastle's {@code AEADParameterSpec} carries the AAD inside the spec
+     * (not via {@code updateAAD}). Since it extends {@code IvParameterSpec}, the
+     * SPI used to swallow it through the IvParameterSpec branch and silently drop
+     * the AAD — computing a tag over no AAD, which then failed to decrypt against
+     * a counterpart that did apply the AAD. This test pins that the AAD is now
+     * honoured for both AEAD modes (GCM and OCB):
+     * <ol>
+     *   <li>JSL encrypt with {@code AEADParameterSpec(iv, 128, aad)} agrees
+     *       byte-for-byte with BouncyCastle on the same spec — proving the AAD is
+     *       folded into the tag identically;</li>
+     *   <li>JSL decrypt via the same spec round-trips;</li>
+     *   <li>decrypting the same ciphertext WITHOUT the AAD fails with
+     *       {@code AEADBadTagException} — the regression guard proving the AAD
+     *       actually participated in authentication (a dropped-AAD implementation
+     *       would decrypt fine here).</li>
+     * </ol>
+     */
+    @Test
+    public void aesAEADParameterSpec_aadHonoured_agreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("aesAEADParameterSpec_aadHonoured_agreesWithBC");
+        for (String xform : new String[]{"AES/GCM/NoPadding", "AES/OCB/NoPadding"})
+        {
+            for (int trial = 0; trial < 10; trial++)
+            {
+                byte[] key = new byte[32];
+                sr.nextBytes(key);
+                byte[] iv = new byte[12];
+                sr.nextBytes(iv);
+                byte[] aad = new byte[1 + sr.nextInt(48)];   // non-empty so the no-AAD guard is meaningful
+                sr.nextBytes(aad);
+                byte[] msg = new byte[1 + sr.nextInt(256)];
+                sr.nextBytes(msg);
+                SecretKey secretKey = new SecretKeySpec(key, "AES");
+
+                org.bouncycastle.jcajce.spec.AEADParameterSpec aeadSpec =
+                        new org.bouncycastle.jcajce.spec.AEADParameterSpec(iv, 128, aad);
+
+                Cipher bcEnc = Cipher.getInstance(xform, BouncyCastleProvider.PROVIDER_NAME);
+                bcEnc.init(Cipher.ENCRYPT_MODE, secretKey, aeadSpec);
+                byte[] bcCT = bcEnc.doFinal(msg);
+
+                Cipher joEnc = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+                joEnc.init(Cipher.ENCRYPT_MODE, secretKey, aeadSpec);
+                byte[] joCT = joEnc.doFinal(msg);
+
+                Assertions.assertArrayEquals(bcCT, joCT,
+                        xform + " trial=" + trial + ": AEADParameterSpec AAD not honoured (diverged from BC)");
+
+                Cipher joDec = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+                joDec.init(Cipher.DECRYPT_MODE, secretKey, aeadSpec);
+                Assertions.assertArrayEquals(msg, joDec.doFinal(joCT),
+                        xform + " trial=" + trial + ": AEADParameterSpec roundtrip failed");
+
+                // Regression guard: same nonce/tag but no AAD must fail.
+                Cipher joDecNoAad = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+                joDecNoAad.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
+                try
+                {
+                    joDecNoAad.doFinal(joCT);
+                    Assertions.fail(xform + " trial=" + trial
+                            + ": decrypt without the AAD must fail when AAD was authenticated");
+                }
+                catch (AEADBadTagException expected)
+                {
+                    // expected — the AAD was folded into the tag
+                }
+            }
         }
     }
 
@@ -3017,6 +3089,66 @@ public class AESAgreementTest
         joDec.init(Cipher.DECRYPT_MODE, secretKey, spec);
         joDec.updateAAD(aad);
         Assertions.assertArrayEquals(msg, joDec.doFinal(joCt), "AES-CCM IvParameterSpec roundtrip failed");
+    }
+
+    /**
+     * CCM must honour a BouncyCastle {@code AEADParameterSpec}'s tag length AND
+     * associated data, not silently treat it as a plain {@code IvParameterSpec}
+     * (which it extends) and drop the AAD. Mirrors the GCM/OCB
+     * {@code aesAEADParameterSpec_aadHonoured_agreesWithBC} test for the separate
+     * CCM SPI: byte-for-byte agreement with BC on the spec-carried-AAD path, a
+     * decrypt round-trip, and a guard that decrypting without the AAD fails.
+     */
+    @Test
+    public void aesCCM_aeadParameterSpec_aadHonoured_agreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("aesCCM_aeadParameterSpec_aadHonoured_agreesWithBC");
+        String xform = "AES/CCM/NoPadding";
+        for (int trial = 0; trial < 10; trial++)
+        {
+            byte[] key = new byte[32];
+            sr.nextBytes(key);
+            byte[] nonce = new byte[7 + sr.nextInt(7)];   // RFC 3610 / CCM: 7..13 bytes
+            sr.nextBytes(nonce);
+            byte[] aad = new byte[1 + sr.nextInt(48)];    // non-empty so the no-AAD guard is meaningful
+            sr.nextBytes(aad);
+            byte[] msg = new byte[1 + sr.nextInt(256)];
+            sr.nextBytes(msg);
+            SecretKey secretKey = new SecretKeySpec(key, "AES");
+
+            org.bouncycastle.jcajce.spec.AEADParameterSpec aeadSpec =
+                    new org.bouncycastle.jcajce.spec.AEADParameterSpec(nonce, 128, aad);
+
+            Cipher bcEnc = Cipher.getInstance(xform, BouncyCastleProvider.PROVIDER_NAME);
+            bcEnc.init(Cipher.ENCRYPT_MODE, secretKey, aeadSpec);
+            byte[] bcCt = bcEnc.doFinal(msg);
+
+            Cipher joEnc = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            joEnc.init(Cipher.ENCRYPT_MODE, secretKey, aeadSpec);
+            byte[] joCt = joEnc.doFinal(msg);
+
+            Assertions.assertArrayEquals(bcCt, joCt,
+                    "trial=" + trial + ": CCM AEADParameterSpec AAD not honoured (diverged from BC)");
+
+            Cipher joDec = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            joDec.init(Cipher.DECRYPT_MODE, secretKey, aeadSpec);
+            Assertions.assertArrayEquals(msg, joDec.doFinal(joCt),
+                    "trial=" + trial + ": CCM AEADParameterSpec roundtrip failed");
+
+            // Regression guard: same nonce/tag but no AAD must fail.
+            Cipher joDecNoAad = Cipher.getInstance(xform, JostleProvider.PROVIDER_NAME);
+            joDecNoAad.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, nonce));
+            try
+            {
+                joDecNoAad.doFinal(joCt);
+                Assertions.fail("trial=" + trial
+                        + ": CCM decrypt without the AAD must fail when AAD was authenticated");
+            }
+            catch (AEADBadTagException expected)
+            {
+                // expected — the AAD was folded into the tag
+            }
+        }
     }
 
     /**

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
@@ -536,6 +536,55 @@ public class AESParametersTest
                 "CCM decrypt initialised from AlgorithmParameters failed");
     }
 
+    /**
+     * Negative path for the hand-rolled RFC 5084 {@code CCMParameters} decoder:
+     * malformed DER must be rejected with {@code IOException}, never silently
+     * accepted (a parser that swallows any bytes would sail through a
+     * positive-only KAT). Covers every rejection branch of the codec's reader.
+     */
+    @Test
+    public void ccmAlgorithmParameters_rejectsMalformedEncodings() throws Exception
+    {
+        // OCTET STRING of a valid 12-byte nonce: 04 0C 00..0B
+        byte[] octetString = {0x04, 0x0c, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b};
+        // A well-formed baseline (ICV default omitted): 30 0E <octetString>.
+        byte[] valid = concat(new byte[]{0x30, 0x0e}, octetString);
+
+        byte[][] malformed = {
+                // wrong outer tag (SET 0x31 instead of SEQUENCE 0x30)
+                concat(new byte[]{0x31, 0x0e}, octetString),
+                // trailing byte after a complete CCMParameters
+                concat(valid, new byte[]{0x00}),
+                // truncated content: SEQUENCE claims 0x0e but only the OCTET STRING header follows
+                {0x30, 0x0e, 0x04, 0x0c, 0x00, 0x01},
+                // unsupported long-form length on the outer SEQUENCE
+                concat(new byte[]{0x30, (byte) 0x81, 0x0e}, octetString),
+                // wrong inner tag (INTEGER 0x02 where an OCTET STRING is required)
+                concat(new byte[]{0x30, 0x0e}, concat(new byte[]{0x02, 0x0c}, java.util.Arrays.copyOfRange(octetString, 2, 14))),
+                // nonce too short (4 bytes < CCM minimum of 7): 30 06 04 04 00 01 02 03
+                {0x30, 0x06, 0x04, 0x04, 0x00, 0x01, 0x02, 0x03},
+                // invalid ICV length (INTEGER 5 is not in {4,6,8,10,12,14,16})
+                concat(concat(new byte[]{0x30, 0x11}, octetString), new byte[]{0x02, 0x01, 0x05}),
+                // empty input
+                new byte[0],
+        };
+
+        for (int i = 0; i < malformed.length; i++)
+        {
+            final byte[] bad = malformed[i];
+            AlgorithmParameters params = AlgorithmParameters.getInstance("CCM", JostleProvider.PROVIDER_NAME);
+            final int idx = i;
+            Assertions.assertThrows(java.io.IOException.class, () -> params.init(bad),
+                    "malformed CCMParameters encoding #" + idx + " must be rejected");
+        }
+
+        // Sanity: the baseline the malformed cases derive from IS accepted.
+        AlgorithmParameters ok = AlgorithmParameters.getInstance("CCM", JostleProvider.PROVIDER_NAME);
+        ok.init(valid);
+        Assertions.assertEquals(12, ok.getParameterSpec(GCMParameterSpec.class).getIV().length,
+                "the well-formed baseline encoding must parse");
+    }
+
     private static byte[] concat(byte[] a, byte[] b)
     {
         byte[] out = new byte[a.length + b.length];

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
@@ -18,10 +18,14 @@ import org.junit.jupiter.api.Test;
 import org.openssl.jostle.jcajce.provider.JostleProvider;
 import org.openssl.jostle.util.Arrays;
 
+import org.openssl.jostle.jcajce.spec.ScryptKeySpec;
+
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -50,6 +54,9 @@ public class AESParametersTest
     private static final String CBC = "AES/CBC/NoPadding";
     private static final String ECB = "AES/ECB/NoPadding";
     private static final String AES256_GCM_OID = "2.16.840.1.101.3.4.1.46";
+    private static final String AES128_CBC_OID = "2.16.840.1.101.3.4.1.2";
+    private static final String AES192_CBC_OID = "2.16.840.1.101.3.4.1.22";
+    private static final String AES256_CBC_OID = "2.16.840.1.101.3.4.1.42";
 
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -186,6 +193,90 @@ public class AESParametersTest
         Cipher bcDec = Cipher.getInstance(CBC, BouncyCastleProvider.PROVIDER_NAME);
         bcDec.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
         Assertions.assertArrayEquals(msg, bcDec.doFinal(ct));
+    }
+
+    @Test
+    public void cbcAlgorithmParametersResolveByOid() throws Exception
+    {
+        // The decrypt-side path BC's PBES2 / PKCS#8 / PKCS#12 decryptors take:
+        // resolve AES-CBC parameters by OID through JSL to recover the stored IV.
+        // All three AES-CBC OIDs (128/192/256) must resolve and codec the IV.
+        SecureRandom random = seededRandom("cbcAlgorithmParametersResolveByOid");
+
+        for (String oid : new String[]{AES128_CBC_OID, AES192_CBC_OID, AES256_CBC_OID})
+        {
+            byte[] iv = new byte[16];
+            random.nextBytes(iv);
+
+            AlgorithmParameters params = AlgorithmParameters.getInstance(oid, JostleProvider.PROVIDER_NAME);
+            params.init(new IvParameterSpec(iv));
+
+            // Encode → decode round-trip (the IV OCTET STRING) preserves the IV.
+            byte[] encoded = params.getEncoded();
+            AlgorithmParameters reparsed = AlgorithmParameters.getInstance(oid, JostleProvider.PROVIDER_NAME);
+            reparsed.init(encoded);
+            Assertions.assertArrayEquals(iv, reparsed.getParameterSpec(IvParameterSpec.class).getIV(),
+                    oid + ": AES-CBC AlgorithmParameters did not round-trip the IV");
+
+            // The encoded form must be portable: BouncyCastle parses JSL's encoding.
+            AlgorithmParameters bcParams = AlgorithmParameters.getInstance(oid, BouncyCastleProvider.PROVIDER_NAME);
+            bcParams.init(encoded);
+            Assertions.assertArrayEquals(iv, bcParams.getParameterSpec(IvParameterSpec.class).getIV(),
+                    oid + ": BC could not parse JSL's AES-CBC parameter encoding");
+
+            // ...and the resolved parameters drive a real CBC decrypt (init purely
+            // from AlgorithmParameters, as the PBES2 receiving side does). The IV
+            // size is independent of the OID's key size, so a 256-bit key is fine.
+            SecretKey key = aes256Key(random);
+            byte[] msg = new byte[48];
+            random.nextBytes(msg);
+            Cipher enc = Cipher.getInstance(CBC, JostleProvider.PROVIDER_NAME);
+            enc.init(Cipher.ENCRYPT_MODE, key, params);
+            byte[] ct = enc.doFinal(msg);
+
+            Cipher dec = Cipher.getInstance(CBC, JostleProvider.PROVIDER_NAME);
+            dec.init(Cipher.DECRYPT_MODE, key, reparsed);
+            Assertions.assertArrayEquals(msg, dec.doFinal(ct),
+                    oid + ": CBC decrypt initialised from AlgorithmParameters failed");
+        }
+    }
+
+    @Test
+    public void cbcAcceptsKdfDerivedKeys() throws Exception
+    {
+        // PBES2 / PKCS#8 hands a KDF-derived key straight to the cipher; the
+        // cipher must accept it despite its non-"AES" algorithm name
+        // (CBC_AUTO_IV_GAP item 2 — validateKeyAlg now accepts PBEKeys).
+        SecureRandom random = seededRandom("cbcAcceptsKdfDerivedKeys");
+        byte[] msg = new byte[48];
+        random.nextBytes(msg);
+        byte[] iv = new byte[16];
+        random.nextBytes(iv);
+        byte[] salt = new byte[16];
+        random.nextBytes(salt);
+        char[] pwd = "password".toCharArray();
+
+        // scrypt-derived key (JOScryptKey, algorithm "ScryptWithUTF8") → AES-256.
+        SecretKey scryptKey = SecretKeyFactory.getInstance("SCRYPT", JostleProvider.PROVIDER_NAME)
+                .generateSecret(new ScryptKeySpec(pwd, salt, 1024, 8, 1, 256));
+        Assertions.assertFalse("AES".equalsIgnoreCase(scryptKey.getAlgorithm()),
+                "precondition: scrypt-derived key is not AES-named");
+        cbcRoundTrip(scryptKey, iv, msg);
+
+        // PBKDF2-derived key (JOPBEKey).
+        SecretKey pbeKey = SecretKeyFactory.getInstance("PBKDF2WITHHMACSHA256", JostleProvider.PROVIDER_NAME)
+                .generateSecret(new PBEKeySpec(pwd, salt, 4096, 256));
+        cbcRoundTrip(pbeKey, iv, msg);
+    }
+
+    private static void cbcRoundTrip(SecretKey key, byte[] iv, byte[] msg) throws Exception
+    {
+        Cipher enc = Cipher.getInstance(CBC, JostleProvider.PROVIDER_NAME);
+        enc.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));   // must not throw "unsupported key algorithm"
+        byte[] ct = enc.doFinal(msg);
+        Cipher dec = Cipher.getInstance(CBC, JostleProvider.PROVIDER_NAME);
+        dec.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
+        Assertions.assertArrayEquals(msg, dec.doFinal(ct), "round-trip with KDF-derived key failed");
     }
 
     @Test

--- a/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/crypto/AESParametersTest.java
@@ -416,4 +416,131 @@ public class AESParametersTest
             Assertions.assertNotNull(c.getIV(), okBits + "-bit GCM tag must be accepted");
         }
     }
+
+    /**
+     * AES-GCM {@code AlgorithmParameters} must now resolve from JSL by the bare
+     * name "GCM" (not just by OID) — the lookup a JSL-bound BC helper performs
+     * via {@code createAlgorithmParameters("GCM")}. Constructing it must NOT
+     * recurse (the delegate is resolved from a non-Jostle provider), the IV/tag
+     * must round-trip, and the encoding must interoperate with BouncyCastle.
+     */
+    @Test
+    public void gcmAlgorithmParametersResolveByName() throws Exception
+    {
+        SecureRandom random = seededRandom("gcmAlgorithmParametersResolveByName");
+        byte[] iv = new byte[12];
+        random.nextBytes(iv);
+
+        AlgorithmParameters params = AlgorithmParameters.getInstance("GCM", JostleProvider.PROVIDER_NAME);
+        params.init(new GCMParameterSpec(128, iv));
+        byte[] encoded = params.getEncoded();
+
+        // Round-trip through JSL's bare-name "GCM".
+        AlgorithmParameters reparsed = AlgorithmParameters.getInstance("GCM", JostleProvider.PROVIDER_NAME);
+        reparsed.init(encoded);
+        GCMParameterSpec spec = reparsed.getParameterSpec(GCMParameterSpec.class);
+        Assertions.assertArrayEquals(iv, spec.getIV(), "GCM name params did not round-trip the nonce");
+        Assertions.assertEquals(128, spec.getTLen(), "GCM name params did not round-trip the tag length");
+
+        // Encoding is portable: the platform GCM AlgorithmParameters (SunJCE,
+        // which is what JSL delegates to) parses JSL's "GCM" encoding back to
+        // the same nonce/tag.
+        AlgorithmParameters platform = AlgorithmParameters.getInstance("GCM");
+        platform.init(encoded);
+        GCMParameterSpec platformSpec = platform.getParameterSpec(GCMParameterSpec.class);
+        Assertions.assertArrayEquals(iv, platformSpec.getIV(),
+                "platform GCM could not parse JSL's bare-name GCM parameter encoding");
+        Assertions.assertEquals(128, platformSpec.getTLen(),
+                "platform GCM read a different tag length from JSL's encoding");
+    }
+
+    /**
+     * AES-CCM {@code AlgorithmParameters} — JSL is the only provider that ships
+     * one (no JDK provider does), so it codes RFC 5084 {@code CCMParameters}
+     * itself. The encoding is pinned to known-answer DER vectors (the gold
+     * standard for a hand-rolled codec): the {@code aes-ICVlen} INTEGER is
+     * omitted at the DEFAULT of 12 bytes and present otherwise. Resolves both by
+     * the bare name "CCM" and the AES-256-CCM OID.
+     */
+    @Test
+    public void ccmAlgorithmParameters_rfc5084Encoding() throws Exception
+    {
+        // Fixed 12-byte nonce so the expected DER is deterministic.
+        byte[] nonce = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b};
+        byte[] octetString = {0x04, 0x0c, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b};
+
+        // SEQUENCE { OCTET STRING nonce }                 -- ICV 12 (DEFAULT, omitted)
+        byte[] expectDefault = concat(new byte[]{0x30, 0x0e}, octetString);
+        // SEQUENCE { OCTET STRING nonce, INTEGER 16 }     -- ICV 16, INTEGER present
+        byte[] expect16 = concat(concat(new byte[]{0x30, 0x11}, octetString), new byte[]{0x02, 0x01, 0x10});
+        // SEQUENCE { OCTET STRING nonce, INTEGER 8 }      -- ICV 8, INTEGER present
+        byte[] expect8 = concat(concat(new byte[]{0x30, 0x11}, octetString), new byte[]{0x02, 0x01, 0x08});
+
+        String aes256CcmOid = "2.16.840.1.101.3.4.1.47";
+        for (String name : new String[]{"CCM", aes256CcmOid})
+        {
+            assertCcmEncoding(name, nonce, 96, expectDefault);   // 96-bit tag => 12-byte ICV (DEFAULT)
+            assertCcmEncoding(name, nonce, 128, expect16);
+            assertCcmEncoding(name, nonce, 64, expect8);
+        }
+    }
+
+    private static void assertCcmEncoding(String name, byte[] nonce, int tagBits, byte[] expectedDer)
+            throws Exception
+    {
+        AlgorithmParameters jsl = AlgorithmParameters.getInstance(name, JostleProvider.PROVIDER_NAME);
+        jsl.init(new GCMParameterSpec(tagBits, nonce));
+        byte[] der = jsl.getEncoded();
+        Assertions.assertArrayEquals(expectedDer, der,
+                name + " tagBits=" + tagBits + ": CCMParameters DER does not match the RFC 5084 vector");
+
+        // Decode round-trip: a fresh instance parses the encoding back.
+        AlgorithmParameters reparsed = AlgorithmParameters.getInstance(name, JostleProvider.PROVIDER_NAME);
+        reparsed.init(der);
+        GCMParameterSpec spec = reparsed.getParameterSpec(GCMParameterSpec.class);
+        Assertions.assertArrayEquals(nonce, spec.getIV(),
+                name + " tagBits=" + tagBits + ": CCMParameters did not round-trip the nonce");
+        Assertions.assertEquals(tagBits, spec.getTLen(),
+                name + " tagBits=" + tagBits + ": CCMParameters did not round-trip the tag length");
+    }
+
+    /**
+     * The CCM {@code AlgorithmParameters} resolved from JSL must drive a real
+     * AES-CCM decrypt — init the cipher purely from the parsed
+     * {@code AlgorithmParameters}, as an OID/params-driven receiver does.
+     */
+    @Test
+    public void ccmAlgorithmParameters_driveCipher() throws Exception
+    {
+        SecureRandom random = seededRandom("ccmAlgorithmParameters_driveCipher");
+        SecretKey key = aes256Key(random);
+        byte[] nonce = new byte[12];
+        random.nextBytes(nonce);
+        byte[] msg = new byte[40];
+        random.nextBytes(msg);
+
+        AlgorithmParameters params = AlgorithmParameters.getInstance("CCM", JostleProvider.PROVIDER_NAME);
+        params.init(new GCMParameterSpec(128, nonce));
+
+        Cipher enc = Cipher.getInstance("AES/CCM/NoPadding", JostleProvider.PROVIDER_NAME);
+        enc.init(Cipher.ENCRYPT_MODE, key, params);
+        byte[] ct = enc.doFinal(msg);
+
+        // Re-encode then re-parse the parameters to exercise the codec end-to-end.
+        AlgorithmParameters reparsed = AlgorithmParameters.getInstance("CCM", JostleProvider.PROVIDER_NAME);
+        reparsed.init(params.getEncoded());
+
+        Cipher dec = Cipher.getInstance("AES/CCM/NoPadding", JostleProvider.PROVIDER_NAME);
+        dec.init(Cipher.DECRYPT_MODE, key, reparsed);
+        Assertions.assertArrayEquals(msg, dec.doFinal(ct),
+                "CCM decrypt initialised from AlgorithmParameters failed");
+    }
+
+    private static byte[] concat(byte[] a, byte[] b)
+    {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
 }

--- a/jostle/src/test/java/org/openssl/jostle/test/kdf/HkdfTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/kdf/HkdfTest.java
@@ -1,0 +1,217 @@
+/*
+ *
+ *   Copyright 2026 OpenSSL Jostle Authors. All Rights Reserved.
+ *
+ *   Licensed under the Apache License 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License.  You can obtain a copy
+ *   in the file LICENSE in the source distribution or at
+ *   https://github.com/openssl-projects/openssl-jostle/blob/main/LICENSE
+ *
+ */
+
+package org.openssl.jostle.test.kdf;
+
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.digests.SHA384Digest;
+import org.bouncycastle.crypto.digests.SHA512Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openssl.jostle.jcajce.provider.JostleProvider;
+import org.openssl.jostle.jcajce.spec.HKDFParameterSpec;
+import org.openssl.jostle.util.Arrays;
+
+import javax.crypto.SecretKeyFactory;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.function.Supplier;
+
+/**
+ * HKDF (RFC 5869) coverage for the native {@code EVP_KDF "HKDF"} surface exposed
+ * as {@code SecretKeyFactory "HKDF-SHA256/384/512"}. Cross-validates against
+ * BouncyCastle's software {@code HKDFBytesGenerator} with random inputs (per the
+ * CLAUDE.md agreement-test discipline), pins an RFC 5869 KAT, and exercises the
+ * negative path (each input must influence the derived key; HKDF is deterministic).
+ */
+public class HkdfTest
+{
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static SecureRandom seededRandom(String testName) throws Exception
+    {
+        long seed = RANDOM.nextLong();
+        System.out.println(testName + " seed=" + seed);
+        SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
+        sr.setSeed(seed);
+        return sr;
+    }
+
+    @BeforeAll
+    static void before()
+    {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(JostleProvider.PROVIDER_NAME) == null)
+        {
+            Security.addProvider(new JostleProvider());
+        }
+    }
+
+    private static byte[] random(int length, SecureRandom sr)
+    {
+        byte[] bytes = new byte[length];
+        sr.nextBytes(bytes);
+        return bytes;
+    }
+
+    private static byte[] bcHkdf(Digest digest, byte[] ikm, byte[] salt, byte[] info, int len)
+    {
+        HKDFBytesGenerator gen = new HKDFBytesGenerator(digest);
+        gen.init(new HKDFParameters(ikm, salt, info));
+        byte[] out = new byte[len];
+        gen.generateBytes(out, 0, len);
+        return out;
+    }
+
+    private static byte[] jostleHkdf(String alg, byte[] ikm, byte[] salt, byte[] info, int len) throws Exception
+    {
+        SecretKeyFactory kf = SecretKeyFactory.getInstance(alg, JostleProvider.PROVIDER_NAME);
+        return kf.generateSecret(new HKDFParameterSpec(ikm, salt, info, len)).getEncoded();
+    }
+
+    /**
+     * Random-input agreement against BouncyCastle for every registered digest.
+     * Varies IKM, salt, info, and output length per trial.
+     */
+    @Test
+    public void testBCAgreement() throws Exception
+    {
+        SecureRandom sr = seededRandom("testBCAgreement");
+
+        String[] algs = {"HKDF-SHA256", "HKDF-SHA384", "HKDF-SHA512"};
+        @SuppressWarnings("unchecked")
+        Supplier<Digest>[] digests = new Supplier[]{
+                (Supplier<Digest>) SHA256Digest::new,
+                (Supplier<Digest>) SHA384Digest::new,
+                (Supplier<Digest>) SHA512Digest::new
+        };
+
+        for (int d = 0; d < algs.length; d++)
+        {
+            for (int trial = 0; trial < 15; trial++)
+            {
+                byte[] ikm = random(1 + sr.nextInt(64), sr);
+                byte[] salt = random(sr.nextInt(48), sr);
+                byte[] info = random(sr.nextInt(48), sr);
+                int len = 1 + sr.nextInt(96);
+
+                byte[] bc = bcHkdf(digests[d].get(), ikm, salt, info, len);
+                byte[] jo = jostleHkdf(algs[d], ikm, salt, info, len);
+
+                Assertions.assertArrayEquals(bc, jo,
+                        algs[d] + " disagreed with BouncyCastle on trial " + trial);
+            }
+        }
+    }
+
+    /**
+     * A null salt must agree with BouncyCastle's null/empty-salt path
+     * (HKDF-Extract with HashLen zeros, RFC 5869 §2.2). The JSL spec stores an
+     * empty salt as null, so this also covers the empty-salt case.
+     */
+    @Test
+    public void testNullSaltAgreesWithBC() throws Exception
+    {
+        SecureRandom sr = seededRandom("testNullSaltAgreesWithBC");
+
+        for (int trial = 0; trial < 10; trial++)
+        {
+            byte[] ikm = random(1 + sr.nextInt(64), sr);
+            byte[] info = random(sr.nextInt(32), sr);
+            int len = 1 + sr.nextInt(64);
+
+            byte[] bc = bcHkdf(new SHA256Digest(), ikm, null, info, len);
+            byte[] jo = jostleHkdf("HKDF-SHA256", ikm, null, info, len);
+
+            Assertions.assertArrayEquals(bc, jo, "null-salt HKDF disagreed with BouncyCastle");
+
+            // Empty salt must be treated identically to a null salt.
+            byte[] joEmptySalt = jostleHkdf("HKDF-SHA256", ikm, new byte[0], info, len);
+            Assertions.assertArrayEquals(bc, joEmptySalt, "empty salt must equal null salt");
+        }
+    }
+
+    /**
+     * RFC 5869 Test Case 1 (HMAC-SHA-256) — a pinned known-answer vector so an
+     * implementation that ignores some input bits cannot pass the agreement test
+     * by coincidence.
+     */
+    @Test
+    public void testRFC5869Vector1() throws Exception
+    {
+        byte[] ikm = Hex.decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        byte[] salt = Hex.decode("000102030405060708090a0b0c");
+        byte[] info = Hex.decode("f0f1f2f3f4f5f6f7f8f9");
+        int len = 42;
+        byte[] expected = Hex.decode(
+                "3cb25f25faacd57a90434f64d0362f2a" +
+                "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" +
+                "34007208d5b887185865");
+
+        byte[] jo = jostleHkdf("HKDF-SHA256", ikm, salt, info, len);
+        Assertions.assertArrayEquals(expected, jo, "RFC 5869 Test Case 1 mismatch");
+    }
+
+    /**
+     * Negative path per CLAUDE.md: each input must influence the derived key, and
+     * HKDF must be deterministic for identical inputs.
+     */
+    @Test
+    public void testInputsActuallyInfluenceDerivedKey() throws Exception
+    {
+        SecureRandom sr = seededRandom("testInputsActuallyInfluenceDerivedKey");
+
+        byte[] ikm1 = random(32, sr);
+        byte[] ikm2 = random(32, sr);
+        byte[] salt1 = random(16, sr);
+        byte[] salt2 = random(16, sr);
+        byte[] info1 = random(16, sr);
+        byte[] info2 = random(16, sr);
+        int len = 48;
+
+        byte[] base = jostleHkdf("HKDF-SHA256", ikm1, salt1, info1, len);
+
+        byte[] diffIkm = jostleHkdf("HKDF-SHA256", ikm2, salt1, info1, len);
+        Assertions.assertFalse(Arrays.areEqual(base, diffIkm),
+                "different IKM must produce a different derived key");
+
+        byte[] diffSalt = jostleHkdf("HKDF-SHA256", ikm1, salt2, info1, len);
+        Assertions.assertFalse(Arrays.areEqual(base, diffSalt),
+                "different salt must produce a different derived key");
+
+        byte[] diffInfo = jostleHkdf("HKDF-SHA256", ikm1, salt1, info2, len);
+        Assertions.assertFalse(Arrays.areEqual(base, diffInfo),
+                "different info must produce a different derived key");
+
+        byte[] diffLen = jostleHkdf("HKDF-SHA256", ikm1, salt1, info1, len / 2);
+        Assertions.assertFalse(Arrays.areEqual(base, diffLen),
+                "a shorter request must not equal a prefix-mismatched longer key");
+
+        // HKDF is deterministic — same inputs, same output.
+        byte[] repeat = jostleHkdf("HKDF-SHA256", ikm1, salt1, info1, len);
+        Assertions.assertArrayEquals(base, repeat,
+                "same inputs must produce the same derived key (HKDF is deterministic)");
+
+        // A different digest must produce a different key for the same inputs.
+        byte[] sha512 = jostleHkdf("HKDF-SHA512", ikm1, salt1, info1, len);
+        Assertions.assertFalse(Arrays.areEqual(base, sha512),
+                "different digest must produce a different derived key");
+    }
+}

--- a/jostle/src/test/java/org/openssl/jostle/test/kdf/ScryptTest.java
+++ b/jostle/src/test/java/org/openssl/jostle/test/kdf/ScryptTest.java
@@ -95,6 +95,34 @@ public class ScryptTest
 
     }
 
+    /**
+     * JSL's SCRYPT {@code SecretKeyFactory} must accept a foreign (BouncyCastle)
+     * {@code ScryptKeySpec} — resolved reflectively via the shared structural
+     * accessor contract, with no compile-time dependency on BC's type — and
+     * derive the identical key it derives from its own {@code ScryptKeySpec}.
+     * Exercises the reflective foreign-spec branch of
+     * {@code ScryptSecretKeyFactory.engineGenerateSecret} (the reason that
+     * branch exists: high-level PBES2/PKCS#8 builders construct BC's spec).
+     */
+    @Test
+    public void scryptFactoryAcceptsForeignKeySpec() throws Exception
+    {
+        SecureRandom sr = seededRandom("scryptFactoryAcceptsForeignKeySpec");
+        char[] passphrase = new String(random(8, sr)).toCharArray();
+        byte[] salt = random(16, sr);
+
+        SecretKeyFactory kfJostle = SecretKeyFactory.getInstance("SCRYPT", JostleProvider.PROVIDER_NAME);
+
+        byte[] viaNativeSpec = kfJostle.generateSecret(
+                new ScryptKeySpec(passphrase, salt, 2, 1, 1, 512)).getEncoded();
+        byte[] viaForeignSpec = kfJostle.generateSecret(
+                new org.bouncycastle.jcajce.spec.ScryptKeySpec(passphrase, salt, 2, 1, 1, 512)).getEncoded();
+
+        Assertions.assertEquals(64, viaNativeSpec.length, "512-bit key expected");
+        Assertions.assertArrayEquals(viaNativeSpec, viaForeignSpec,
+                "JSL SCRYPT factory derived a different key from a BouncyCastle ScryptKeySpec");
+    }
+
 
     /**
      * Negative path per CLAUDE.md "Tests must exercise the negative


### PR DESCRIPTION
Adds correct handling of the BC AEADParameterSpec for introducing AEAD
Adds missing algorithm parameters for CBC/CCM/GCM
Adds support for Scrypt/HKDF using reflection based BC parameters