### PR TITLE
CI: sign and publish from Jenkins, not GitHub Actions

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -262,12 +262,18 @@ jobs:
         working-directory: "jostle"
         # Slim, self-contained per-arch bundle carrying only this arch's natives.
         # The Maven classifier (archClassifier) keeps it from colliding with the
-        # aarch64 bundle under one coordinate. sources/javadoc are arch-independent
-        # and built in the publish job, not here.
+        # aarch64 bundle under one coordinate; it applies to the main jar only, so
+        # sources/javadoc keep their own classifiers. Release builds also produce
+        # the -sources/-javadoc jars Maven Central requires.
         env:
           VERSION: "${{ inputs.version }}"
+          RELEASE: "${{ inputs.release }}"
         run: |
-          ./gradlew jar -ParchClassifier=x86_64 ${VERSION:+-Pversion="$VERSION"}
+          TASKS="jar"
+          if [ "$RELEASE" = "true" ]; then
+            TASKS="jar sourcesJar javadocJar"
+          fi
+          ./gradlew $TASKS -ParchClassifier=x86_64 ${VERSION:+-Pversion="$VERSION"}
       - name: "Upload x86_64 bundle"
         uses: "actions/upload-artifact@v7"
         with:
@@ -303,12 +309,18 @@ jobs:
         working-directory: "jostle"
         # Slim, self-contained per-arch bundle carrying only this arch's natives.
         # The Maven classifier (archClassifier) keeps it from colliding with the
-        # x86_64 bundle under one coordinate. sources/javadoc are arch-independent
-        # and built in the publish job, not here.
+        # x86_64 bundle under one coordinate; it applies to the main jar only, so
+        # sources/javadoc keep their own classifiers. Release builds also produce
+        # the -sources/-javadoc jars Maven Central requires.
         env:
           VERSION: "${{ inputs.version }}"
+          RELEASE: "${{ inputs.release }}"
         run: |
-          ./gradlew jar -ParchClassifier=aarch64 ${VERSION:+-Pversion="$VERSION"}
+          TASKS="jar"
+          if [ "$RELEASE" = "true" ]; then
+            TASKS="jar sourcesJar javadocJar"
+          fi
+          ./gradlew $TASKS -ParchClassifier=aarch64 ${VERSION:+-Pversion="$VERSION"}
       - name: "Upload aarch64 bundle"
         uses: "actions/upload-artifact@v7"
         with:
@@ -316,40 +328,3 @@ jobs:
           path: "jostle/jostle/build/libs/*.jar"
           if-no-files-found: "error"
           retention-days: 7
-
-  # Publishes the pom-packaged coordinate (openssl-jostle) with both per-arch
-  # bundles attached as classifier artifacts, plus arch-independent sources and
-  # javadoc, all GPG-signed. No fat main jar and no native download: the bundles
-  # arrive pre-built from the package jobs. Gated on a release build AND a
-  # protected environment (manual approval + scoped secrets).
-  publish:
-    needs: ["package-x86_64", "package-aarch64"]
-    if: ${{ inputs.release == true }}
-    runs-on: "ubuntu-latest"
-    environment: "maven-central"
-    steps:
-      - name: "Checkout jostle"
-        uses: "actions/checkout@v7"
-        with:
-          persist-credentials: false
-          path: "jostle"
-      - uses: "actions/setup-java@v5"
-        with:
-          distribution: "corretto"
-          java-version: '25'
-      - name: "Stage the per-arch bundles"
-        uses: "actions/download-artifact@v8"
-        with:
-          pattern: "jostle-jar-*"
-          merge-multiple: true
-          path: "jostle/staged-jars"
-      - name: "Build sources + javadoc, sign, and publish"
-        working-directory: "jostle"
-        env:
-          VERSION: "${{ inputs.version }}"
-          CENTRAL_USERNAME: "${{ secrets.CENTRAL_USERNAME }}"
-          CENTRAL_PASSWORD: "${{ secrets.CENTRAL_PASSWORD }}"
-          SIGNING_KEY: "${{ secrets.SIGNING_KEY }}"
-          SIGNING_PASSWORD: "${{ secrets.SIGNING_PASSWORD }}"
-        run: |
-          ./gradlew sourcesJar javadocJar publish ${VERSION:+-Pversion="$VERSION"}

--- a/jostle/build.gradle
+++ b/jostle/build.gradle
@@ -224,30 +224,30 @@ artifacts {
 // each a self-contained multi-release jar carrying that architecture's native
 // libraries for all supported OSes. There is deliberately NO classifier-less
 // main jar: a bare dependency resolves to the POM only, so a consumer MUST
-// request a classifier, e.g. "org.openssl:openssl-jostle:<v>:x86_64".
+// request a classifier, e.g. "org.openssl.jostle:openssl-jostle:<v>:x86_64".
 //
 // The per-arch bundles are built on separate CI runners (each with only one
-// arch's natives present) and staged into ${rootDir}/staged-jars by the publish
-// job before this runs; sources/javadoc are architecture-independent and built
-// here. Publishing only happens when the four credential env vars are present,
-// so dev builds and the CI test matrix are unaffected.
+// arch's natives present) and staged into ${rootDir}/staged-jars by the Jenkins
+// publish job — after it has JCE-signed them on the HSM — before this runs;
+// sources/javadoc are architecture-independent and built here. Nothing reads
+// this publication except Gradle's own `publish` task, so dev builds and the
+// CI test matrix are unaffected.
 //
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'org.openssl'            // TODO: confirm the Central namespace you own
+            groupId = 'org.openssl.jostle'
             artifactId = 'openssl-jostle'
             version = project.version
 
             // No main jar; this is a pom-packaged umbrella over the bundles.
             pom.packaging = 'pom'
 
-            // Per-arch bundles, staged by the publish job. Empty (no attachments)
-            // on any build that hasn't staged them, which is fine — only `publish`
-            // consumes this publication.
+            // Per-arch bundles, staged by the Jenkins pipeline. Empty (no
+            // attachments) on any build that hasn't staged them, which is fine —
+            // nothing reads this publication except Gradle's `publish` task.
             fileTree(dir: "${rootDir}/staged-jars", include: '*.jar').each { f ->
                 def m = (f.name =~ /-(x86_64|aarch64)\.jar$/)
                 if (m) {
@@ -287,13 +287,15 @@ publishing {
     }
     repositories {
         maven {
-            name = 'central'
-            def snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
-            // TODO: set -PcentralReleaseUrl (or the vanniktech / gradle-nexus plugin)
-            // to your Central release endpoint. The .invalid default fails loudly so
-            // a release publish can never silently push to the wrong place.
-            def releaseUrl = findProperty('centralReleaseUrl') ?: 'https://replace-with-central-release-endpoint.invalid/'
-            url = version.toString().endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
+            // Staging only: render the repository tree, upload nothing. The
+            // Jenkins publish job PGP-signs it on the HSM and uploads — releases
+            // as a Central Portal bundle, snapshots to the snapshot repo.
+            // Snapshots stage too, so they cannot skip signing.
+            name = 'staging'
+            // Override to deploy straight to a repository instead.
+            url = findProperty('centralReleaseUrl')
+                    ?: layout.buildDirectory.dir('staging-deploy').get().asFile.toURI().toString()
+            // Only used when the URL above is overridden to a remote.
             credentials {
                 username = System.getenv('CENTRAL_USERNAME')
                 password = System.getenv('CENTRAL_PASSWORD')
@@ -310,16 +312,6 @@ publishing {
 tasks.withType(GenerateModuleMetadata).configureEach {
     enabled = false
 }
-
-signing {
-    def signingKey = System.getenv('SIGNING_KEY')            // ASCII-armored PGP private key
-    def signingPassword = System.getenv('SIGNING_PASSWORD')
-    if (signingKey) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.mavenJava
-    }
-}
-
 
 sourceSets {
     //


### PR DESCRIPTION
The signing keys cannot leave the HSM, so no PGP key or Central credential can live in a GitHub secret. Drop the workflow's publish job and Gradle's in-memory PGP signing: GitHub Actions builds the per-arch bundles, OpenSSL signing infrastructure signs and uploads them.

Publishing now always stages to a local directory, since Central takes releases as a bundle rather than a maven deploy, and staging snapshots too keeps them from skipping PGP signing. Also fix the groupId to the registered namespace org.openssl.jostle and restore -sources/-javadoc to release builds.